### PR TITLE
Vagrant host-only network IP changed to meet new VirtualBox rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/*
 .vagrant
 *.bak
+.dccache

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.13.37"
+  config.vm.network "private_network", ip: "192.168.56.37"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
 
   echo ""
   echo "# Example customized deployment directory and domain name:"
-  echo "#   PLEXTRAC_HOME=/var/apps/plextrac-demo CLIENT_DOMAIN_NAME=192.168.13.37 ./plextrac initialize"
+  echo "#   PLEXTRAC_HOME=/var/apps/plextrac-demo CLIENT_DOMAIN_NAME=192.168.56.37 ./plextrac initialize"
   echo ""
 
   echo "Initializing PlexTrac at default location..."


### PR DESCRIPTION
# What
This PR changes the Vagrant host-only network IP from `192.168.13.37` to `192.168.56.37` to comply with the IP range restrictions introduced in VirtualBox v1.6.30

(The PR also adds the Snyk local cache file to the `.gitignore` in a totally unrelated commit 😬 ) 

# Why
VirtualBox introduced new restrictions on the IP range for host-only networks in version 1.6.30

Here's the VirtualBox docs about the IP range restriction:
https://www.virtualbox.org/manual/ch06.html#network_hostonly

> On Linux, Mac OS X and Solaris Oracle VM VirtualBox will only allow IP addresses in 192.168.56.0/21 range to be assigned to host-only adapters

# Some console output
Without this change in place, I get the following console output while running `vagrant up` (with VirtualBox v1.6.30):

```
vagrant up
Bringing machine 'test-cli-setup' up with 'virtualbox' provider...
==> test-cli-setup: Checking if box 'bento/ubuntu-20.04' version '202107.28.0' is up to date...
==> test-cli-setup: Clearing any previously set network interfaces...
There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["hostonlyif", "ipconfig", "vboxnet0", "--ip", "192.168.13.1", "--netmask", "255.255.255.0"]

Stderr: VBoxManage: error: Code E_ACCESSDENIED (0x80070005) - Access denied (extended info not available)
VBoxManage: error: Context: "EnableStaticIPConfig(Bstr(pszIp).raw(), Bstr(pszNetmask).raw())" at line 242 of file VBoxManageHostonly.cpp
```