### PR TITLE
QUICK-170 add notifications services to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ This is the PlexTrac management CLI that can be used to perform the initial setu
         configure                            does initial configuration required for PlexTrac application
         info                                 display information about the current PlexTrac Instance
 
-### For a fresh install of a new PlexTrac instance:
+## For a fresh install of a new PlexTrac instance:
 
     DOCKER_HUB_KEY=${DOCKER_HUB_KEY} plextrac configure
     plextrac update
     plextrac start
+
+### A quick note about the `DOCKER_HUB_KEY`
+It should look several groups of alphanumeric characters separated by hyphens. It should _not_ be base64-encoded.
+Example: `abcd123-11a1-22bb-c3c3-defg567890`
 
 ## Testing inside a Vagrant box
 
@@ -38,13 +42,15 @@ You'll need to have [Vagrant](https://www.vagrantup.com/) installed before you c
 
 3.  Create a default `.env` file by running the `configure` command
 
-        plextrac configure
+        DOCKER_HUB_KEY=<YOUR_DOCKER_HUB_KEY> plextrac configure
 
-4.  Set your DOCKER_HUB_KEY environment variable in the `.env` file
+    This will write a `.env` file to `/opt/plextrac/.env` with default values plus the DOCKER_HUB_KEY that you just provided.
+
+4.  Set any non-default environment variables in the `.env` file
 
         vim /opt/plextrac/.env
 
-    You should update the following vars:
+    You should check the following vars:
 
         DOCKER_HUB_KEY    # Your token for pulling images from the plextrac private Docker Hub registry
         UPGRADE_STRATEGY  # A docker image tag to pull (i.e. 'stable', 'edge', 'imminent', or a git commitish)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
 # plextrac-manager-util
+
+This is the PlexTrac management CLI that can be used to perform the initial setup of a new PlexTrac installation as well as performing maintenance tasks on running instances.
+
+## Usage
+
+    Usage: plextrac COMMAND [FLAGS]
+
+    [+] Available commands:
+        initialize                           initialize local system for PlexTrac installation
+        install                              install PlexTrac (assumes previously initialized system)
+        start                                run the PlexTrac application
+        backup                               perform backup on currently running PlexTrac application
+        check                                checks for version & status of PlexTrac application
+        configure                            does initial configuration required for PlexTrac application
+        info                                 display information about the current PlexTrac Instance
+
+### For a fresh install of a new PlexTrac instance:
+
+    DOCKER_HUB_KEY=${DOCKER_HUB_KEY} plextrac configure
+    plextrac update
+    plextrac start
+
+## Testing inside a Vagrant box
+
+This repo is bundled with a [Vagrant](https://www.vagrantup.com/) configuration so that the CLI can be tested inside a virtual machine without polluting your host machine.
+
+You'll need to have [Vagrant](https://www.vagrantup.com/) installed before you can use the preconfigured virtual machine.
+
+1.  Start up the Vagrant virtual machine:
+
+        vagrant up
+
+2.  SSH into the Vagrant VM and become the `plextrac` user
+
+        vagrant ssh
+        sudo -iu plextrac
+
+3.  Create a default `.env` file by running the `configure` command
+
+        plextrac configure
+
+4.  Set your DOCKER_HUB_KEY environment variable in the `.env` file
+
+        vim /opt/plextrac/.env
+
+    You should update the following vars:
+
+        DOCKER_HUB_KEY    # Your token for pulling images from the plextrac private Docker Hub registry
+        UPGRADE_STRATEGY  # A docker image tag to pull (i.e. 'stable', 'edge', 'imminent', or a git commitish)
+
+    You should also set any feature flag or `OVERRIDE` vars in the `.env` file now, _for example_:
+
+        OVERRIDE_TRANSACTION_ID_LOGGING=true
+
+5.  Start the Plextrac application
+
+        plextrac start
+
+6.  You can tail logs:
+
+    ...for a specific service:
+
+        docker-compose logs -f <SERVICE_NAME>
+
+    Example:
+
+        docker-compose logs -f plextracapi
+
+    ...or for the entire stack all at once:
+
+        docker-compose logs -f

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is the PlexTrac management CLI that can be used to perform the initial setu
     DOCKER_HUB_KEY=${DOCKER_HUB_KEY} plextrac install -y
 
 ### A quick note about the `DOCKER_HUB_KEY`
+
 It should look several groups of alphanumeric characters separated by hyphens. It should _not_ be base64-encoded.
 Example: `abcd123-11a1-22bb-c3c3-defg567890`
 
@@ -74,3 +75,11 @@ You'll need to have [Vagrant](https://www.vagrantup.com/) installed before you c
     ...or for the entire stack all at once:
 
         docker-compose logs -f
+
+## Development
+
+To test changes to the bash scripts, you can SSH into the running Vagrant box and re-compile the plextrac cli by running
+
+    /vagrant/src/plextrac dist > /opt/plextrac/.local/bin/plextrac
+
+Then run whatever cli command you were editing. I.e. `plextrac info`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.13.37"
+  config.vm.network "private_network", ip: "192.168.56.37"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
 
   echo ""
   echo "# Example customized deployment directory and domain name:"
-  echo "#   PLEXTRAC_HOME=/var/apps/plextrac-demo CLIENT_DOMAIN_NAME=192.168.13.37 ./plextrac initialize"
+  echo "#   PLEXTRAC_HOME=/var/apps/plextrac-demo CLIENT_DOMAIN_NAME=192.168.56.37 ./plextrac initialize"
   echo ""
 
   echo "Initializing PlexTrac at default location..."

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -84,7 +84,11 @@ Vagrant.configure("2") do |config|
   echo ""
   echo -n 'RE9DS0VSX0hVQl9LRVk9JChqcSAnLmF1dGhzLiJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iLmF1dGgnIH4vLmRvY2tlci9jb25maWcuanNvbiAtciB8IGJhc2U2NCAtZCB8IGN1dCAtZCc6JyAtZjIpOwo=' | base64 -d
   echo ""
-  echo "If on MacOS/Windows, please figure out where that is stored and issue a PR to add support here :)"
+  echo "On MacOS, this can be retrieved using the following command (enter login passphrase in the prompt(s):"
+  echo ""
+  echo -n 'RE9DS0VSX0hVQl9LRVk9JChzZWN1cml0eSBmaW5kLWludGVybmV0LXBhc3N3b3JkIC1hIHBsZXh0cmFjdXNlcnMgLXMgaW5kZXguZG9ja2VyLmlvIC13KTsK' | base64 -d
+  echo ""
+  echo "If on Windows, please figure out where that is stored and issue a PR to add support here :)"
   echo ""
   echo "One-liner configuration for Linux users:"
   echo ""

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -30,6 +30,11 @@ function mod_info() {
   info "Disk Statistics"
   msg `check_disk_capacity`
   msg `info_backupDiskUsage`
+  echo >&2 ""
+
+  title "Notifications"
+  info "Summary"
+  msg "`compose_client exec plextracapi npm run status:notifications | fgrep -v '> '`"
 }
 
 function info_TLSCertificateDetails() {

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -133,7 +133,7 @@ volumes:
   dbdata: {}
   uploads: {}
   letsencrypt: {}
-  redis: 
+  redis:
     driver: local
     driver_opts:
       type: 'none'

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -93,6 +93,12 @@ services:
       LOG_LEVEL: "${LOG_LEVEL:-error}"
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
+    healthcheck:
+      test: ["CMD", "node", "./dist/apps/notification-engine/scripts/healthcheck.js", "readiness", "10"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
     entrypoint: npm run
     command: "start:notification-engine"
 

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
     healthcheck:
-      test: ["CMD", "node", "./dist/apps/notification-engine/scripts/healthcheck.js", "readiness", "10"]
+      test: ["CMD", "npm", "run", "healthcheck:notification-engine", "readiness", "10"]
       interval: 5s
       timeout: 5s
       retries: 3
@@ -119,6 +119,8 @@ services:
       NOTIFICATION_DRY_RUN: ${NOTIFICATION_DRY_RUN}
       serviceConfig: ${serviceConfig}
       MAILER_SECURE: ${MAILER_SECURE}
+    healthcheck:
+      test: ["CMD", "npm", "run", "healthcheck:notification-sender", "readiness"]
     entrypoint: npm run
     command: "start:notification-sender"
 

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -80,6 +80,42 @@ services:
     volumes:
     - letsencrypt:/etc/letsencrypt:rw
 
+  notification-engine:
+    image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+    depends_on:
+      - plextracdb
+      - redis
+    restart: always
+    environment:
+      CB_API_PASS: "${CB_API_PASS:?err}"
+      CB_API_USER: "${CB_API_USER:?err}"
+      COUCHBASE_URL: "http://plextracdb"
+      LOG_LEVEL: "${LOG_LEVEL:-error}"
+      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
+    entrypoint: npm run
+    command: "start:notification-engine"
+
+  notification-sender:
+    image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+    depends_on:
+      - plextracdb
+      - redis
+    restart: always
+    environment:
+      CB_API_PASS: "${CB_API_PASS:?err}"
+      CB_API_USER: "${CB_API_USER:?err}"
+      COUCHBASE_URL: "http://plextracdb"
+      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:-err}
+      LOG_LEVEL: ${LOG_LEVEL:-error}
+      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
+      NOTIFICATION_DRY_RUN: ${NOTIFICATION_DRY_RUN}
+      serviceConfig: ${serviceConfig}
+      MAILER_SECURE: ${MAILER_SECURE}
+    entrypoint: npm run
+    command: "start:notification-sender"
+
   redis:
     image: redis:6.2-alpine
     command: "redis-server --requirepass ${REDIS_PASSWORD}"
@@ -91,18 +127,8 @@ volumes:
   dbdata: {}
   uploads: {}
   letsencrypt: {}
-  redis:
-    driver: local
-    driver_opts:
-      type: 'none'
-      o: 'bind'
-      device: '${PLEXTRAC_HOME:-.}/volumes/redis'
-  couchbase-backups:
-    driver: local
-    driver_opts:
-      type: 'none'
-      o: 'bind'
-      device: '${PLEXTRAC_HOME:-.}/backups/couchbase'
+  redis: {}
+  couchbase-backups: {}
 
 networks:
   default:

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   plextracapi:
@@ -9,7 +9,7 @@ services:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     restart: always
     volumes:
-    - uploads:/usr/src/plextrac-api/uploads:rw
+      - uploads:/usr/src/plextrac-api/uploads:rw
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -22,7 +22,7 @@ services:
       - plextracdb
       - redis
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
-    entrypoint: ''
+    entrypoint: ""
     command: |
       sh -c
         "npm run maintenance:enable &&
@@ -48,14 +48,14 @@ services:
       bucket: "${bucket-}"
     image: plextrac/plextracdb:6.5.1
     ports:
-    - 127.0.0.1:8091:8091/tcp
-    - 127.0.0.1:8092:8092/tcp
-    - 127.0.0.1:8093:8093/tcp
-    - 127.0.0.1:8094:8094/tcp
+      - 127.0.0.1:8091:8091/tcp
+      - 127.0.0.1:8092:8092/tcp
+      - 127.0.0.1:8093:8093/tcp
+      - 127.0.0.1:8094:8094/tcp
     restart: always
     volumes:
-    - dbdata:/opt/couchbase/var:rw
-    - couchbase-backups:/backups:rw
+      - dbdata:/opt/couchbase/var:rw
+      - couchbase-backups:/backups:rw
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -74,11 +74,11 @@ services:
       HIDE_PAGE_TITLE: "${HIDE_PAGE_TITLE-}"
       OVERRIDE_SENTRY_FRONTEND_ENABLED: "${OVERRIDE_SENTRY_FRONTEND_ENABLED-}"
     ports:
-    - 0.0.0.0:80:80/tcp
-    - 0.0.0.0:443:443/tcp
+      - 0.0.0.0:80:80/tcp
+      - 0.0.0.0:443:443/tcp
     restart: always
     volumes:
-    - letsencrypt:/etc/letsencrypt:rw
+      - letsencrypt:/etc/letsencrypt:rw
 
   notification-engine:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
@@ -94,7 +94,15 @@ services:
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
     healthcheck:
-      test: ["CMD", "npm", "run", "healthcheck:notification-engine", "readiness", "10"]
+      test:
+        [
+          "CMD",
+          "npm",
+          "run",
+          "healthcheck:notification-engine",
+          "readiness",
+          "10",
+        ]
       interval: 5s
       timeout: 5s
       retries: 3
@@ -116,11 +124,12 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-error}
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
-      NOTIFICATION_DRY_RUN: ${NOTIFICATION_DRY_RUN}
-      serviceConfig: ${serviceConfig}
-      MAILER_SECURE: ${MAILER_SECURE}
+      NOTIFICATION_DRY_RUN: ${NOTIFICATION_DRY_RUN:-}
+      serviceConfig: ${serviceConfig:-}
+      MAILER_SECURE: ${MAILER_SECURE:-}
     healthcheck:
-      test: ["CMD", "npm", "run", "healthcheck:notification-sender", "readiness"]
+      test:
+        ["CMD", "npm", "run", "healthcheck:notification-sender", "readiness"]
     entrypoint: npm run
     command: "start:notification-sender"
 
@@ -129,7 +138,7 @@ services:
     command: "redis-server --requirepass ${REDIS_PASSWORD}"
     container_name: redis
     volumes:
-    - redis:/etc/redis:rw
+      - redis:/etc/redis:rw
 
 volumes:
   dbdata: {}
@@ -138,15 +147,15 @@ volumes:
   redis:
     driver: local
     driver_opts:
-      type: 'none'
-      o: 'bind'
-      device: '${PLEXTRAC_HOME:-.}/volumes/redis'
+      type: "none"
+      o: "bind"
+      device: "${PLEXTRAC_HOME:-.}/volumes/redis"
   couchbase-backups:
     driver: local
     driver_opts:
-      type: 'none'
-      o: 'bind'
-      device: '${PLEXTRAC_HOME:-.}/backups/couchbase'
+      type: "none"
+      o: "bind"
+      device: "${PLEXTRAC_HOME:-.}/backups/couchbase"
 
 networks:
   default:

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   plextracapi:
@@ -9,7 +9,7 @@ services:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     restart: always
     volumes:
-    - uploads:/usr/src/plextrac-api/uploads:rw
+      - uploads:/usr/src/plextrac-api/uploads:rw
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -22,7 +22,7 @@ services:
       - plextracdb
       - redis
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
-    entrypoint: ''
+    entrypoint: ""
     command: |
       sh -c
         "npm run maintenance:enable &&
@@ -48,14 +48,14 @@ services:
       bucket: "${bucket-}"
     image: plextrac/plextracdb:6.5.1
     ports:
-    - 127.0.0.1:8091:8091/tcp
-    - 127.0.0.1:8092:8092/tcp
-    - 127.0.0.1:8093:8093/tcp
-    - 127.0.0.1:8094:8094/tcp
+      - 127.0.0.1:8091:8091/tcp
+      - 127.0.0.1:8092:8092/tcp
+      - 127.0.0.1:8093:8093/tcp
+      - 127.0.0.1:8094:8094/tcp
     restart: always
     volumes:
-    - dbdata:/opt/couchbase/var:rw
-    - couchbase-backups:/backups:rw
+      - dbdata:/opt/couchbase/var:rw
+      - couchbase-backups:/backups:rw
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -74,11 +74,11 @@ services:
       HIDE_PAGE_TITLE: "${HIDE_PAGE_TITLE-}"
       OVERRIDE_SENTRY_FRONTEND_ENABLED: "${OVERRIDE_SENTRY_FRONTEND_ENABLED-}"
     ports:
-    - 0.0.0.0:80:80/tcp
-    - 0.0.0.0:443:443/tcp
+      - 0.0.0.0:80:80/tcp
+      - 0.0.0.0:443:443/tcp
     restart: always
     volumes:
-    - letsencrypt:/etc/letsencrypt:rw
+      - letsencrypt:/etc/letsencrypt:rw
 
   notification-engine:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
@@ -106,7 +106,7 @@ services:
       CB_API_PASS: "${CB_API_PASS:?err}"
       CB_API_USER: "${CB_API_USER:?err}"
       COUCHBASE_URL: "http://plextracdb"
-      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:-err}
+      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
       LOG_LEVEL: ${LOG_LEVEL:-error}
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
@@ -121,7 +121,7 @@ services:
     command: "redis-server --requirepass ${REDIS_PASSWORD}"
     container_name: redis
     volumes:
-    - redis:/etc/redis:rw
+      - redis:/etc/redis:rw
 
 volumes:
   dbdata: {}

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -5,22 +5,22 @@ services:
     environment:
       STARTUP_MODE: API_ONLY
     env_file:
-      - .env
+    - .env
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     restart: always
     volumes:
-      - uploads:/usr/src/plextrac-api/uploads:rw
+    - uploads:/usr/src/plextrac-api/uploads:rw
     healthcheck:
       test:
-        - "CMD-SHELL"
-        - "curl http://localhost:4350/api/v2/health/live"
+      - "CMD-SHELL"
+      - "curl http://localhost:4350/api/v2/health/live"
 
   couchbase-migrations:
     profiles:
-      - "database-migrations"
+    - "database-migrations"
     depends_on:
-      - plextracdb
-      - redis
+    - plextracdb
+    - redis
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     entrypoint: ""
     command: |
@@ -48,18 +48,18 @@ services:
       bucket: "${bucket-}"
     image: plextrac/plextracdb:6.5.1
     ports:
-      - 127.0.0.1:8091:8091/tcp
-      - 127.0.0.1:8092:8092/tcp
-      - 127.0.0.1:8093:8093/tcp
-      - 127.0.0.1:8094:8094/tcp
+    - 127.0.0.1:8091:8091/tcp
+    - 127.0.0.1:8092:8092/tcp
+    - 127.0.0.1:8093:8093/tcp
+    - 127.0.0.1:8094:8094/tcp
     restart: always
     volumes:
-      - dbdata:/opt/couchbase/var:rw
-      - couchbase-backups:/backups:rw
+    - dbdata:/opt/couchbase/var:rw
+    - couchbase-backups:/backups:rw
     healthcheck:
       test:
-        - "CMD-SHELL"
-        - "curl --head --fail -X GET -u $CB_ADMIN_USER:$CB_ADMIN_PASS -H 'Content-Type: application/json' http://localhost:8091/pools/default/buckets/reportMe || exit 1"
+      - "CMD-SHELL"
+      - "curl --head --fail -X GET -u $CB_ADMIN_USER:$CB_ADMIN_PASS -H 'Content-Type: application/json' http://localhost:8091/pools/default/buckets/reportMe || exit 1"
       interval: 10s
       retries: 6
       start_period: 30s
@@ -74,35 +74,29 @@ services:
       HIDE_PAGE_TITLE: "${HIDE_PAGE_TITLE-}"
       OVERRIDE_SENTRY_FRONTEND_ENABLED: "${OVERRIDE_SENTRY_FRONTEND_ENABLED-}"
     ports:
-      - 0.0.0.0:80:80/tcp
-      - 0.0.0.0:443:443/tcp
+    - 0.0.0.0:80:80/tcp
+    - 0.0.0.0:443:443/tcp
     restart: always
     volumes:
-      - letsencrypt:/etc/letsencrypt:rw
+    - letsencrypt:/etc/letsencrypt:rw
 
   notification-engine:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     depends_on:
-      - plextracdb
-      - redis
+    - plextracdb
+    - redis
     restart: always
     environment:
       CB_API_PASS: "${CB_API_PASS:?err}"
       CB_API_USER: "${CB_API_USER:?err}"
       COUCHBASE_URL: "http://plextracdb"
-      LOG_LEVEL: "${LOG_LEVEL:-error}"
+      LOG_LEVEL: "${LOG_LEVEL:-info}"
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
     healthcheck:
       test:
-        [
-          "CMD",
-          "npm",
-          "run",
-          "healthcheck:notification-engine",
-          "readiness",
-          "10",
-        ]
+      - "CMD"
+      - "npm run healthcheck:notification-engine readiness 10"
       interval: 5s
       timeout: 5s
       retries: 3
@@ -113,15 +107,15 @@ services:
   notification-sender:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     depends_on:
-      - plextracdb
-      - redis
+    - plextracdb
+    - redis
     restart: always
     environment:
       CB_API_PASS: "${CB_API_PASS:?err}"
       CB_API_USER: "${CB_API_USER:?err}"
       COUCHBASE_URL: "http://plextracdb"
       CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
-      LOG_LEVEL: ${LOG_LEVEL:-error}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
       NOTIFICATION_DRY_RUN: ${NOTIFICATION_DRY_RUN:-}
@@ -129,7 +123,8 @@ services:
       MAILER_SECURE: ${MAILER_SECURE:-}
     healthcheck:
       test:
-        ["CMD", "npm", "run", "healthcheck:notification-sender", "readiness"]
+      - "CMD"
+      - "npm run healthcheck:notification-sender readiness"
     entrypoint: npm run
     command: "start:notification-sender"
 
@@ -138,7 +133,7 @@ services:
     command: "redis-server --requirepass ${REDIS_PASSWORD}"
     container_name: redis
     volumes:
-      - redis:/etc/redis:rw
+    - redis:/etc/redis:rw
 
 volumes:
   dbdata: {}

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: '3.8'
 
 services:
   plextracapi:
@@ -9,7 +9,7 @@ services:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     restart: always
     volumes:
-      - uploads:/usr/src/plextrac-api/uploads:rw
+    - uploads:/usr/src/plextrac-api/uploads:rw
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -22,7 +22,7 @@ services:
       - plextracdb
       - redis
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
-    entrypoint: ""
+    entrypoint: ''
     command: |
       sh -c
         "npm run maintenance:enable &&
@@ -48,14 +48,14 @@ services:
       bucket: "${bucket-}"
     image: plextrac/plextracdb:6.5.1
     ports:
-      - 127.0.0.1:8091:8091/tcp
-      - 127.0.0.1:8092:8092/tcp
-      - 127.0.0.1:8093:8093/tcp
-      - 127.0.0.1:8094:8094/tcp
+    - 127.0.0.1:8091:8091/tcp
+    - 127.0.0.1:8092:8092/tcp
+    - 127.0.0.1:8093:8093/tcp
+    - 127.0.0.1:8094:8094/tcp
     restart: always
     volumes:
-      - dbdata:/opt/couchbase/var:rw
-      - couchbase-backups:/backups:rw
+    - dbdata:/opt/couchbase/var:rw
+    - couchbase-backups:/backups:rw
     healthcheck:
       test:
         - "CMD-SHELL"
@@ -74,11 +74,11 @@ services:
       HIDE_PAGE_TITLE: "${HIDE_PAGE_TITLE-}"
       OVERRIDE_SENTRY_FRONTEND_ENABLED: "${OVERRIDE_SENTRY_FRONTEND_ENABLED-}"
     ports:
-      - 0.0.0.0:80:80/tcp
-      - 0.0.0.0:443:443/tcp
+    - 0.0.0.0:80:80/tcp
+    - 0.0.0.0:443:443/tcp
     restart: always
     volumes:
-      - letsencrypt:/etc/letsencrypt:rw
+    - letsencrypt:/etc/letsencrypt:rw
 
   notification-engine:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
@@ -121,14 +121,24 @@ services:
     command: "redis-server --requirepass ${REDIS_PASSWORD}"
     container_name: redis
     volumes:
-      - redis:/etc/redis:rw
+    - redis:/etc/redis:rw
 
 volumes:
   dbdata: {}
   uploads: {}
   letsencrypt: {}
-  redis: {}
-  couchbase-backups: {}
+  redis: 
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: '${PLEXTRAC_HOME:-.}/volumes/redis'
+  couchbase-backups:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: '${PLEXTRAC_HOME:-.}/backups/couchbase'
 
 networks:
   default:


### PR DESCRIPTION
# WAT?
This PR adds two new services to the `docker-compose.yml` file to support the event-based Notifications system.
The new services are:
  - `notification-engine`
  - `notification-sender`

# Testing it

The setup steps that I added to the  README document the steps that I was using to set up a new Plextrac instance inside the Vagrant box.

  - Follow the setup instructions that have been added to the Readme to get a PlexTrac instance set up with this new docker-compose config.
  - Check the "Health" of the notification-engine and notification-sender (as reported by docker-compose via the new healthcheck) by running these commands inside the Vagrant box:
  
         docker-compose ps

    This should show that both the 'engine' and 'sender' are "Healthy".

  - Stop the Redis container. This should cause the notification services to become unhealthy (after a short delay).
  
         docker-compose stop redis

  - Continue to check the health of the services for about 40 seconds to make sure that docker-compose recognizes that they're unhealthy
  - Turn Redis back on and make sure that the services become healthy again automatically
  
         docker-compose up -d redis
