### PR TITLE
QUICK-414 fixes health checks for the notification services

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -98,7 +98,11 @@ services:
     healthcheck:
       test:
       - "CMD"
-      - "npm run healthcheck:notification-engine readiness 10"
+      - "npm"
+      - "run"
+      - "healthcheck:notification-engine"
+      - "readiness"
+      - "10"
       interval: 5s
       timeout: 5s
       retries: 3
@@ -128,7 +132,10 @@ services:
     healthcheck:
       test:
       - "CMD"
-      - "npm run healthcheck:notification-sender readiness"
+      - "npm"
+      - "run"
+      - "healthcheck:notification-sender"
+      - "readiness"
     entrypoint: npm run
     command: "start:notification-sender"
 

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -83,7 +83,7 @@ services:
   notification-engine:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     deploy:
-      replicas: 0
+      replicas: 1
     depends_on:
     - plextracdb
     - redis
@@ -113,7 +113,7 @@ services:
   notification-sender:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     deploy:
-      replicas: 0
+      replicas: 1
     depends_on:
     - plextracdb
     - redis


### PR DESCRIPTION
The health checks for the notification services were failing when @jesseops attempted to roll them out to some production environments last week. Turns out this was due to a syntactical issue in the docker-compose file where the health checks are configured. The health checks now match what we have in the kubernetes manifests for these services, with each argument being on a separate line in the docker-compose file.

Note: To test this, you'll have to re-enable the notification services by bumping the `replicas` count on them up to 1.

### Testing Steps
**_Assuming you have a Vagrant environment setup already._**

**Note: To test this, you'll have to re-enable the notification services by bumping the `replicas` count on them up to 1.**

1. Checkout `release/v0.2.x-bash`
2. `plextrac start`
3. `plextrac info`
4. Observe that the notification-engine and notification-sender services are unhealthy.
5. Checkout `QUICK-414`
6. `plextrac start`
7. `plextrac info`
8. Observe that the services are now healthy.
