### PR TITLE
Just use script name instead of hardcoding the expected path

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,8 +23,8 @@ The latest release can be retrieved from GitHub:
 ```console
 $ curl -Ls `curl -Ls https://api.github.com/repos/PlexTrac/plextrac-manager-util/releases/latest \
     | jq -r '.assets[].browser_download_url'` \
-    > /tmp/plextrac-cli
-$ chmod a+x /tmp/plextrac-cli; sudo /tmp/plextrac-cli initialize
+    > /tmp/plextrac
+$ chmod a+x /tmp/plextrac; sudo /tmp/plextrac initialize
 
 ______ _         _____              
 | ___ \ |       |_   _|             

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -26,7 +26,7 @@ function copy_scripts() {
   info "Copying plextrac CLI to user PATH..."
   tmp=`mktemp -p /tmp plextrac-XXX`
   debug "tmp script location: $tmp"
-  debug "`$(dirname $0)/plextrac dist 2>/dev/null > $tmp && cp -uv $tmp "${PLEXTRAC_HOME}/.local/bin/plextrac"`"
+  debug "`$0 dist 2>/dev/null > $tmp && cp -uv $tmp "${PLEXTRAC_HOME}/.local/bin/plextrac"`"
   chmod +x "${PLEXTRAC_HOME}/.local/bin/plextrac"
   log "Done."
 }


### PR DESCRIPTION
Also, update docs to be in sync with common usage