### PR TITLE
CLOUDOPS-10 stub out postgres support stuff

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+tasks:
+  - init: |
+      echo 'TODO: build project'
+    command: |
+      echo 'TODO: start app'

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -56,8 +56,9 @@ BACKUP_DIR=/opt/couchbase/backups
 PLEXTRAC_PARSER_URL=https://plextracparser:4443
 UPGRADE_STRATEGY=${UPGRADE_STRATEGY:-"stable"}
 PLEXTRAC_BACKUP_PATH="${PLEXTRAC_BACKUP_PATH:-$PLEXTRAC_HOME/backups}"
-"
 
+\`generate_default_postgres_env\`
+"
 
   # Merge the generated env with the local vars
   # Preference is given to the generated data so we can force new
@@ -89,7 +90,8 @@ PLEXTRAC_BACKUP_PATH="${PLEXTRAC_BACKUP_PATH:-$PLEXTRAC_HOME/backups}"
 }
 
 function generateSecret() {
-  echo `head -c 64 /dev/urandom | base64 | head -c 32`
+  # replace any non-alphanumeric characters so postgres doesn't choke
+  echo `head -c 64 /dev/urandom | base64 | tr -cd '[:alnum:]._-' | head -c 32`
 }
 
 function login_dockerhub() {

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -44,20 +44,13 @@ USE_MAILER_SSL=${USE_MAILER_SSL:-false}
 COUCHBASE_URL=${couchbaseComposeService}
 REDIS_PASSWORD=${REDIS_PASSWORD:-`generateSecret`}
 REDIS_CONNECTION_STRING=redis
-CB_BUCKET=reportMe
-CB_API_USER=${CB_API_USER:-"ptapiuser"}
-CB_ADMIN_USER=${CB_ADMIN_USER:-"ptadminuser"}
-CB_BACKUP_USER=${CB_BACKUP_USER:-"ptbackupuser"}
-CB_API_PASS=${CB_API_PASS:-`generateSecret`}
-CB_ADMIN_PASS=${CB_ADMIN_PASS:-`generateSecret`}
-CB_BACKUP_PASS=${CB_BACKUP_PASS:-`generateSecret`}
 RUNAS_APPUSER=True
-BACKUP_DIR=/opt/couchbase/backups
 PLEXTRAC_PARSER_URL=https://plextracparser:4443
 UPGRADE_STRATEGY=${UPGRADE_STRATEGY:-"stable"}
 PLEXTRAC_BACKUP_PATH="${PLEXTRAC_BACKUP_PATH:-$PLEXTRAC_HOME/backups}"
 
-\`generate_default_postgres_env\`
+`generate_default_couchbase_env | setDefaultSecrets`
+`generate_default_postgres_env | setDefaultSecrets`
 "
 
   # Merge the generated env with the local vars
@@ -92,6 +85,19 @@ PLEXTRAC_BACKUP_PATH="${PLEXTRAC_BACKUP_PATH:-$PLEXTRAC_HOME/backups}"
 function generateSecret() {
   # replace any non-alphanumeric characters so postgres doesn't choke
   echo `head -c 64 /dev/urandom | base64 | tr -cd '[:alnum:]._-' | head -c 32`
+}
+
+function setDefaultSecrets() {
+  OLDIFS=$IFS
+  export IFS==
+  while read var val; do
+    if [ $val == "<secret>" ]; then
+      val='`generateSecret`'
+    fi
+    eval "echo `printf '%s=${%s:-%s}\n' $var $var $val`"
+    #echo "$var=${var:-$val}"
+  done < "${1:-/dev/stdin}"
+  export IFS=$OLDIFS
 }
 
 function login_dockerhub() {

--- a/src/_manage_couchbase.sh
+++ b/src/_manage_couchbase.sh
@@ -1,5 +1,22 @@
 ## Functions for managing the Couchbase database
 
+couchbaseUsers=('API' 'ADMIN' 'BACKUP')
+
+function generate_default_couchbase_env() {
+  cat <<- ENDCOUCHBASE
+`
+  echo CB_BUCKET=reportMe
+  echo POSTGRES_USER=internalonly
+  echo "POSTGRES_PASSWORD=<secret>"
+  echo BACKUP_DIR=/opt/couchbase/backups
+  for user in ${couchbaseUsers[@]}; do
+    echo "CB_${user}_USER=pt${db,,}user"
+    echo "CB_${user}_PASS=<secret>"
+  done
+`
+ENDCOUCHBASE
+}
+
 function manage_api_user() {
   info "Creating unprivileged user ${CB_API_USER} with access to ${CB_BUCKET}"
   get_user_approval

--- a/src/_manage_couchbase.sh
+++ b/src/_manage_couchbase.sh
@@ -10,7 +10,7 @@ function generate_default_couchbase_env() {
   echo "POSTGRES_PASSWORD=<secret>"
   echo BACKUP_DIR=/opt/couchbase/backups
   for user in ${couchbaseUsers[@]}; do
-    echo "CB_${user}_USER=pt${db,,}user"
+    echo "CB_${user}_USER=pt${user,,}user"
     echo "CB_${user}_PASS=<secret>"
   done
 `

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -1,5 +1,58 @@
 ## Functions for managing the Postgres Database
 
+postgresDatabases=('CORE' 'RUNBOOKS')
+
+function generate_default_postgres_env() {
+  cat <<- ENDPOSTGRES
+`
+  echo PG_HOST=postgres
+  echo POSTGRES_USER=internalonly
+  echo "POSTGRES_PASSWORD=<secret>"
+  for db in ${postgresDatabases[@]}; do
+    echo "PG_${db}_DB=${db,,}"
+    echo "PG_${db}_ADMIN_USER=${db,,}_admin"
+    echo "PG_${db}_ADMIN_PASSWORD=<secret>"
+    echo "PG_${db}_RW_USER=${db,,}_rw"
+    echo "PG_${db}_RW_PASSWORD=<secret>"
+    echo "PG_${db}_RO_USER=${db,,}_ro"
+    echo "PG_${db}_RO_PASSWORD=<secret>"
+  done
+`
+ENDPOSTGRES
+}
+
+
+# -- START SECRET GENERATION SCRIPT --
+#!/bin/bash
+#  
+#  PG_DATABASES=("CORE" "RUNBOOKS")
+#  
+#  function generatePostgresDatabaseCredentials() {
+#    echo "PG_$1_ADMIN_USER=${1,,}_admin"
+#    echo -n "PG_$1_ADMIN_PASSWORD="; generateSecret
+#    echo "PG_$1_RW_USER=${1,,}_rw"
+#    echo -n "PG_$1_RW_PASSWORD="; generateSecret
+#    echo "PG_$1_RO_USER=${1,,}_ro"
+#    echo -n "PG_$1_RO_PASSWORD="; generateSecret
+#  }
+#  
+#  function generateSecret() {
+#    echo `head -c 64 /dev/urandom | base64 | tr -cd '[:alnum:]._-' | head -c 32`
+#  }
+#  
+#  function main() {
+#    echo "PG_HOST=postgres"
+#    echo "POSTGRES_USER=ullr"
+#    echo -n "POSTGRES_PASSWORD="; generateSecret
+#    for db in "${PG_DATABASES[@]}"; do
+#      echo "PG_${db}_DB=`echo $db | awk '{ print tolower($0) }'`"
+#      generatePostgresDatabaseCredentials $db
+#    done
+#  }
+#  
+#  main
+# -- END SECRET GENERATION SCRIPT --
+
 
 # From UAT
 #
@@ -62,34 +115,3 @@
 #      psql -a -v ON_ERROR_STOP=1 --username $POSTGRES_USER -d $POSTGRES_USER
 #  done
 # -- START INITDB SCRIPT --
-# -- START SECRET GENERATION SCRIPT --
-#!/bin/bash
-#  
-#  PG_DATABASES=("CORE" "RUNBOOKS")
-#  
-#  function generatePostgresDatabaseCredentials() {
-#    echo "PG_$1_ADMIN_USER=${1,,}_admin"
-#    echo -n "PG_$1_ADMIN_PASSWORD="; generateSecret
-#    echo "PG_$1_RW_USER=${1,,}_rw"
-#    echo -n "PG_$1_RW_PASSWORD="; generateSecret
-#    echo "PG_$1_RO_USER=${1,,}_ro"
-#    echo -n "PG_$1_RO_PASSWORD="; generateSecret
-#  }
-#  
-#  function generateSecret() {
-#    echo `head -c 64 /dev/urandom | base64 | tr -cd '[:alnum:]._-' | head -c 32`
-#  }
-#  
-#  function main() {
-#    echo "PG_HOST=postgres"
-#    echo "POSTGRES_USER=ullr"
-#    echo -n "POSTGRES_PASSWORD="; generateSecret
-#    for db in "${PG_DATABASES[@]}"; do
-#      echo "PG_${db}_DB=`echo $db | awk '{ print tolower($0) }'`"
-#      generatePostgresDatabaseCredentials $db
-#    done
-#  }
-#  
-#  main
-# -- END SECRET GENERATION SCRIPT --
-

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -1,0 +1,95 @@
+## Functions for managing the Postgres Database
+
+
+# From UAT
+#
+# -- START SQL TEMPLATE --
+#  -- Add Service Roles
+#  --
+#  -- Service Admin
+#  CREATE USER $PG_PLACEHOLDER_ADMIN_USER WITH PASSWORD '$PG_PLACEHOLDER_ADMIN_PASSWORD';
+#  -- Service Read-Only User
+#  CREATE USER $PG_PLACEHOLDER_RO_USER WITH PASSWORD '$PG_PLACEHOLDER_RO_PASSWORD';
+#  -- Service Read-Write User
+#  CREATE USER $PG_PLACEHOLDER_RW_USER WITH PASSWORD '$PG_PLACEHOLDER_RW_PASSWORD';
+#  
+#  -- Role memberships
+#  -- Each role inherits from the role below
+#  GRANT $PG_PLACEHOLDER_RO_USER TO $PG_PLACEHOLDER_RW_USER;
+#  GRANT $PG_PLACEHOLDER_RW_USER TO $PG_PLACEHOLDER_ADMIN_USER;
+#  
+#  -- Create Service Database $PG_PLACEHOLDER_DB
+#  CREATE DATABASE $PG_PLACEHOLDER_DB;
+#  REVOKE ALL ON DATABASE $PG_PLACEHOLDER_DB FROM public;
+#  GRANT CONNECT ON DATABASE $PG_PLACEHOLDER_DB TO $PG_PLACEHOLDER_RO_USER;
+#  
+#  -- switch to the new database.
+#  \connect $PG_PLACEHOLDER_DB;
+#  
+#  -- Schema level grants within $PG_PLACEHOLDER_DB db
+#  --
+#  -- Service Read-Only user needs basic access
+#  GRANT USAGE ON SCHEMA public TO $PG_PLACEHOLDER_RO_USER;
+#  
+#  -- Only the admin account should ever create new resources
+#  -- This also marks Service Admin account as owner of new resources
+#  GRANT CREATE ON SCHEMA public TO $PG_PLACEHOLDER_ADMIN_USER;
+#  
+#  -- Enable read access to all new tables for Service Read-Only
+#  ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
+#      GRANT SELECT ON TABLES TO $PG_PLACEHOLDER_RO_USER;
+#  
+#  -- Enable read-write access to all new tables for Service Read-Write
+#  ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
+#      GRANT INSERT,DELETE,TRUNCATE,UPDATE ON TABLES TO $PG_PLACEHOLDER_RW_USER;
+#  
+#  -- Need to enable usage on sequences for Service Read-Write
+#  -- to enable auto-incrementing ids
+#  ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
+#      GRANT USAGE ON SEQUENCES TO $PG_PLACEHOLDER_RW_USER;
+# -- END SQL TEMPLATE --
+#
+# -- START INITDB SCRIPT --
+#  #!/bin/bash
+#  
+#  PGPASSWORD="$POSTGRES_PASSWORD"
+#  
+#  tmpl=`cat /docker-entrypoint-initdb.d/bootstrap-template.sql.txt`
+#  
+#  for db in core runbooks; do
+#    # Ugh this is ugly. Thanks Bash
+#    eval "echo "'"'"`echo "$tmpl" | sed "s/PLACEHOLDER/${db^^}/g" -`"'"'"" |
+#      psql -a -v ON_ERROR_STOP=1 --username $POSTGRES_USER -d $POSTGRES_USER
+#  done
+# -- START INITDB SCRIPT --
+# -- START SECRET GENERATION SCRIPT --
+#!/bin/bash
+#  
+#  PG_DATABASES=("CORE" "RUNBOOKS")
+#  
+#  function generatePostgresDatabaseCredentials() {
+#    echo "PG_$1_ADMIN_USER=${1,,}_admin"
+#    echo -n "PG_$1_ADMIN_PASSWORD="; generateSecret
+#    echo "PG_$1_RW_USER=${1,,}_rw"
+#    echo -n "PG_$1_RW_PASSWORD="; generateSecret
+#    echo "PG_$1_RO_USER=${1,,}_ro"
+#    echo -n "PG_$1_RO_PASSWORD="; generateSecret
+#  }
+#  
+#  function generateSecret() {
+#    echo `head -c 64 /dev/urandom | base64 | tr -cd '[:alnum:]._-' | head -c 32`
+#  }
+#  
+#  function main() {
+#    echo "PG_HOST=postgres"
+#    echo "POSTGRES_USER=ullr"
+#    echo -n "POSTGRES_PASSWORD="; generateSecret
+#    for db in "${PG_DATABASES[@]}"; do
+#      echo "PG_${db}_DB=`echo $db | awk '{ print tolower($0) }'`"
+#      generatePostgresDatabaseCredentials $db
+#    done
+#  }
+#  
+#  main
+# -- END SECRET GENERATION SCRIPT --
+

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -1,6 +1,7 @@
 ## Functions for managing the Postgres Database
 
 postgresDatabases=('CORE' 'RUNBOOKS')
+postgresUsers=('ADMIN' 'RW' 'RO')
 
 function generate_default_postgres_env() {
   cat <<- ENDPOSTGRES
@@ -10,12 +11,10 @@ function generate_default_postgres_env() {
   echo "POSTGRES_PASSWORD=<secret>"
   for db in ${postgresDatabases[@]}; do
     echo "PG_${db}_DB=${db,,}"
-    echo "PG_${db}_ADMIN_USER=${db,,}_admin"
-    echo "PG_${db}_ADMIN_PASSWORD=<secret>"
-    echo "PG_${db}_RW_USER=${db,,}_rw"
-    echo "PG_${db}_RW_PASSWORD=<secret>"
-    echo "PG_${db}_RO_USER=${db,,}_ro"
-    echo "PG_${db}_RO_PASSWORD=<secret>"
+    for user in ${postgresUsers[@]}; do
+      echo "PG_${db}_${user}_USER=${db,,}_${user,,}"
+      echo "PG_${db}_${user}_PASSWORD=<secret>"
+    done
   done
 `
 ENDPOSTGRES

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -20,97 +20,69 @@ function generate_default_postgres_env() {
 ENDPOSTGRES
 }
 
+function deploy_volume_contents_postgres() {
+  info "Adding postgres initdb scripts to Docker volume"
+  targetDir=`compose_client config --format=json | jq -r \
+    '.volumes[] | select(.name | test("postgres-initdb")) | 
+      .driver_opts.device'`
+  debug "Adding scripts to $targetDir"
+  cat > "$targetDir/bootstrap-template.sql.txt" <<- "EOBOOTSTRAPTEMPLATE"
+-- Add Service Roles
+--
+-- Service Admin
+CREATE USER $PG_PLACEHOLDER_ADMIN_USER WITH PASSWORD '$PG_PLACEHOLDER_ADMIN_PASSWORD';
+-- Service Read-Only User
+CREATE USER $PG_PLACEHOLDER_RO_USER WITH PASSWORD '$PG_PLACEHOLDER_RO_PASSWORD';
+-- Service Read-Write User
+CREATE USER $PG_PLACEHOLDER_RW_USER WITH PASSWORD '$PG_PLACEHOLDER_RW_PASSWORD';
 
-# -- START SECRET GENERATION SCRIPT --
+-- Role memberships
+-- Each role inherits from the role below
+GRANT $PG_PLACEHOLDER_RO_USER TO $PG_PLACEHOLDER_RW_USER;
+GRANT $PG_PLACEHOLDER_RW_USER TO $PG_PLACEHOLDER_ADMIN_USER;
+
+-- Create Service Database $PG_PLACEHOLDER_DB
+CREATE DATABASE $PG_PLACEHOLDER_DB;
+REVOKE ALL ON DATABASE $PG_PLACEHOLDER_DB FROM public;
+GRANT CONNECT ON DATABASE $PG_PLACEHOLDER_DB TO $PG_PLACEHOLDER_RO_USER;
+
+-- switch to the new database.
+\connect $PG_PLACEHOLDER_DB;
+
+-- Schema level grants within $PG_PLACEHOLDER_DB db
+--
+-- Service Read-Only user needs basic access
+GRANT USAGE ON SCHEMA public TO $PG_PLACEHOLDER_RO_USER;
+
+-- Only the admin account should ever create new resources
+-- This also marks Service Admin account as owner of new resources
+GRANT CREATE ON SCHEMA public TO $PG_PLACEHOLDER_ADMIN_USER;
+
+-- Enable read access to all new tables for Service Read-Only
+ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
+    GRANT SELECT ON TABLES TO $PG_PLACEHOLDER_RO_USER;
+
+-- Enable read-write access to all new tables for Service Read-Write
+ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
+    GRANT INSERT,DELETE,TRUNCATE,UPDATE ON TABLES TO $PG_PLACEHOLDER_RW_USER;
+
+-- Need to enable usage on sequences for Service Read-Write
+-- to enable auto-incrementing ids
+ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
+    GRANT USAGE ON SEQUENCES TO $PG_PLACEHOLDER_RW_USER;
+EOBOOTSTRAPTEMPLATE
+  cat > "$targetDir/initdb.sh" <<- "EOINITDBSCRIPT"
 #!/bin/bash
-#  
-#  PG_DATABASES=("CORE" "RUNBOOKS")
-#  
-#  function generatePostgresDatabaseCredentials() {
-#    echo "PG_$1_ADMIN_USER=${1,,}_admin"
-#    echo -n "PG_$1_ADMIN_PASSWORD="; generateSecret
-#    echo "PG_$1_RW_USER=${1,,}_rw"
-#    echo -n "PG_$1_RW_PASSWORD="; generateSecret
-#    echo "PG_$1_RO_USER=${1,,}_ro"
-#    echo -n "PG_$1_RO_PASSWORD="; generateSecret
-#  }
-#  
-#  function generateSecret() {
-#    echo `head -c 64 /dev/urandom | base64 | tr -cd '[:alnum:]._-' | head -c 32`
-#  }
-#  
-#  function main() {
-#    echo "PG_HOST=postgres"
-#    echo "POSTGRES_USER=ullr"
-#    echo -n "POSTGRES_PASSWORD="; generateSecret
-#    for db in "${PG_DATABASES[@]}"; do
-#      echo "PG_${db}_DB=`echo $db | awk '{ print tolower($0) }'`"
-#      generatePostgresDatabaseCredentials $db
-#    done
-#  }
-#  
-#  main
-# -- END SECRET GENERATION SCRIPT --
 
+PGPASSWORD="$POSTGRES_PASSWORD"
+PGDATABASES=('core' 'runbooks')
 
-# From UAT
-#
-# -- START SQL TEMPLATE --
-#  -- Add Service Roles
-#  --
-#  -- Service Admin
-#  CREATE USER $PG_PLACEHOLDER_ADMIN_USER WITH PASSWORD '$PG_PLACEHOLDER_ADMIN_PASSWORD';
-#  -- Service Read-Only User
-#  CREATE USER $PG_PLACEHOLDER_RO_USER WITH PASSWORD '$PG_PLACEHOLDER_RO_PASSWORD';
-#  -- Service Read-Write User
-#  CREATE USER $PG_PLACEHOLDER_RW_USER WITH PASSWORD '$PG_PLACEHOLDER_RW_PASSWORD';
-#  
-#  -- Role memberships
-#  -- Each role inherits from the role below
-#  GRANT $PG_PLACEHOLDER_RO_USER TO $PG_PLACEHOLDER_RW_USER;
-#  GRANT $PG_PLACEHOLDER_RW_USER TO $PG_PLACEHOLDER_ADMIN_USER;
-#  
-#  -- Create Service Database $PG_PLACEHOLDER_DB
-#  CREATE DATABASE $PG_PLACEHOLDER_DB;
-#  REVOKE ALL ON DATABASE $PG_PLACEHOLDER_DB FROM public;
-#  GRANT CONNECT ON DATABASE $PG_PLACEHOLDER_DB TO $PG_PLACEHOLDER_RO_USER;
-#  
-#  -- switch to the new database.
-#  \connect $PG_PLACEHOLDER_DB;
-#  
-#  -- Schema level grants within $PG_PLACEHOLDER_DB db
-#  --
-#  -- Service Read-Only user needs basic access
-#  GRANT USAGE ON SCHEMA public TO $PG_PLACEHOLDER_RO_USER;
-#  
-#  -- Only the admin account should ever create new resources
-#  -- This also marks Service Admin account as owner of new resources
-#  GRANT CREATE ON SCHEMA public TO $PG_PLACEHOLDER_ADMIN_USER;
-#  
-#  -- Enable read access to all new tables for Service Read-Only
-#  ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
-#      GRANT SELECT ON TABLES TO $PG_PLACEHOLDER_RO_USER;
-#  
-#  -- Enable read-write access to all new tables for Service Read-Write
-#  ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
-#      GRANT INSERT,DELETE,TRUNCATE,UPDATE ON TABLES TO $PG_PLACEHOLDER_RW_USER;
-#  
-#  -- Need to enable usage on sequences for Service Read-Write
-#  -- to enable auto-incrementing ids
-#  ALTER DEFAULT PRIVILEGES FOR ROLE $PG_PLACEHOLDER_ADMIN_USER
-#      GRANT USAGE ON SEQUENCES TO $PG_PLACEHOLDER_RW_USER;
-# -- END SQL TEMPLATE --
-#
-# -- START INITDB SCRIPT --
-#  #!/bin/bash
-#  
-#  PGPASSWORD="$POSTGRES_PASSWORD"
-#  
-#  tmpl=`cat /docker-entrypoint-initdb.d/bootstrap-template.sql.txt`
-#  
-#  for db in core runbooks; do
-#    # Ugh this is ugly. Thanks Bash
-#    eval "echo "'"'"`echo "$tmpl" | sed "s/PLACEHOLDER/${db^^}/g" -`"'"'"" |
-#      psql -a -v ON_ERROR_STOP=1 --username $POSTGRES_USER -d $POSTGRES_USER
-#  done
-# -- START INITDB SCRIPT --
+tmpl=`cat /docker-entrypoint-initdb.d/bootstrap-template.sql.txt`
+
+for db in ${PGDATABASES[@]}; do
+  # Ugh this is ugly. Thanks Bash
+  eval "echo "'"'"`echo "$tmpl" | sed "s/PLACEHOLDER/${db^^}/g" -`"'"'"" |
+    psql -a -v ON_ERROR_STOP=1 --username $POSTGRES_USER -d $POSTGRES_USER
+done
+EOINITDBSCRIPT
+}

--- a/src/plextrac
+++ b/src/plextrac
@@ -256,6 +256,7 @@ function mod_configure() {
   login_dockerhub
   updateComposeConfig
   create_volume_directories
+  deploy_volume_contents_postgres
 }
 
 function mod_start() {

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       CB_API_PASS: ${CB_API_PASS}
       CB_API_USER: ${CB_API_USER}
+      OVERRIDE_RUNBOOKS_V2: true
       REDIS_CONNECTION_STRING: ${REDIS_CONNECTION_STRING:-redis}
       REDIS_PASSWORD: ${REDIS_PASSWORD:?err}
 
@@ -148,10 +149,25 @@ services:
     - redis:/etc/redis:rw
     restart: always
 
+  postgres:
+    image: postgres:14-alpine
+    env_file:
+    # The output of the secrets generation needs to be appended to this file
+    - .env
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+      POSTGRES_INITDB_ARGS: '--auth-local=scram-sha-256 --auth-host=scram-sha-256'
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+    # this is where the initdb script & SQL template go
+    - /opt/plextrac/volumes/postgres-initdb:/docker-entrypoint-initdb.d
+    - postgres-data:/var/lib/postgresql/data
+
 volumes:
   dbdata: {}
   uploads: {}
   letsencrypt: {}
+  postgres-data: {}
   redis:
     driver: local
     driver_opts:

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -31,7 +31,6 @@ services:
     environment:
       CB_API_PASS: ${CB_API_PASS}
       CB_API_USER: ${CB_API_USER}
-      OVERRIDE_RUNBOOKS_V2: true
       REDIS_CONNECTION_STRING: ${REDIS_CONNECTION_STRING:-redis}
       REDIS_PASSWORD: ${REDIS_PASSWORD:?err}
 
@@ -160,7 +159,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
     # this is where the initdb script & SQL template go
-    - /opt/plextrac/volumes/postgres-initdb:/docker-entrypoint-initdb.d
+    - postgres-initdb:/docker-entrypoint-initdb.d
     - postgres-data:/var/lib/postgresql/data
 
 volumes:
@@ -168,6 +167,12 @@ volumes:
   uploads: {}
   letsencrypt: {}
   postgres-data: {}
+  postgres-initdb:
+    driver: local
+    driver_opts:
+      type: "none"
+      o: "bind"
+      device: "${PLEXTRAC_HOME:-.}/volumes/postgres-initdb"
   redis:
     driver: local
     driver_opts:


### PR DESCRIPTION
This should be a start if @rkeeler wants to take a stab at it.

I already have all of this working in the UAT environment, but I manually added the secrets (using the script provided here) to the .env. I _think_ the way I have the volumes setup is at least close to optimal, but I've slept once or twice since doing this build.