### PR TITLE
QUICK-576 wire up pg schema migrations and etl

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -2,6 +2,10 @@ version: "3.8"
 
 services:
   plextracapi:
+    depends_on:
+    - plextracdb
+    - redis
+    - postgres
     environment:
       STARTUP_MODE: API_ONLY
     env_file:
@@ -26,6 +30,7 @@ services:
     depends_on:
     - plextracdb
     - redis
+    - postgres
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     volumes:
     - uploads:/usr/src/plextrac-api/uploads:rw
@@ -38,12 +43,12 @@ services:
          npm run pg:etl up all &&
          npm run maintenance:disable"
     environment:
-      COUCHBASE_URL: "http://plextracdb"
+      COUCHBASE_URL: ${COUCHBASE_URL:-http://plextracdb}
       CB_API_PASS: ${CB_API_PASS}
       CB_API_USER: ${CB_API_USER}
       REDIS_CONNECTION_STRING: ${REDIS_CONNECTION_STRING:-redis}
       REDIS_PASSWORD: ${REDIS_PASSWORD:?err}
-      PG_HOST: postgres
+      PG_HOST: ${PG_HOST:-postgres}
       PG_MIGRATE_PATH: /usr/src/plextrac-api
       PG_CORE_ADMIN_PASSWORD: ${PG_CORE_ADMIN_PASSWORD:?err}
       PG_CORE_ADMIN_USER: ${PG_CORE_ADMIN_USER:?err}

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -27,17 +27,32 @@ services:
     - plextracdb
     - redis
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+    volumes:
+    - uploads:/usr/src/plextrac-api/uploads:rw
     entrypoint: ""
     command: |
       sh -c
         "npm run maintenance:enable &&
          npm run db:migrate &&
+         npm run pg:migrate &&
+         npm run pg:etl up all &&
          npm run maintenance:disable"
     environment:
+      COUCHBASE_URL: "http://plextracdb"
       CB_API_PASS: ${CB_API_PASS}
       CB_API_USER: ${CB_API_USER}
       REDIS_CONNECTION_STRING: ${REDIS_CONNECTION_STRING:-redis}
       REDIS_PASSWORD: ${REDIS_PASSWORD:?err}
+      PG_HOST: postgres
+      PG_MIGRATE_PATH: /usr/src/plextrac-api
+      PG_CORE_ADMIN_PASSWORD: ${PG_CORE_ADMIN_PASSWORD:?err}
+      PG_CORE_ADMIN_USER: ${PG_CORE_ADMIN_USER:?err}
+      PG_CORE_DB: ${PG_CORE_DB:?err}
+      PG_RUNBOOKS_ADMIN_PASSWORD: ${PG_RUNBOOKS_ADMIN_PASSWORD:?err}
+      PG_RUNBOOKS_ADMIN_USER: ${PG_RUNBOOKS_ADMIN_USER:?err}
+      PG_RUNBOOKS_DB: ${PG_RUNBOOKS_DB:?err}
+      PG_TENANTS_WRITE_MODE: ${PG_TENANTS_WRITE_MODE:-couchbase_only}
+      PG_TENANTS_READ_MODE: ${PG_TENANTS_READ_MODE:-couchbase_only}
 
   plextracdb:
     environment:


### PR DESCRIPTION
The postgres db container was recently rolled out, but our application code is not referencing it. This PR wires things up so that the postges schema migrations and ETL are triggered as part of the migration job. And the tenant dual write/read env var is wired up so that we can do the canary rollout by changing those env vars in the .env file and not having to ship new infra changes.