### PR TITLE
Added wildcard support for all docker-compose*.yml files

### DIFF
--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -6,8 +6,9 @@ postgresComposeService="postgres"
 
 function compose_client() {
   flags=($@)
-  debug "executing docker-compose ${flags[@]}"
-  compose_files=$(for i in `ls docker-compose*.yml`; do printf " -f ${PLEXTRAC_HOME}/%s" "$i"; done )
+  compose_files=$(for i in `ls ${PLEXTRAC_HOME}/docker-compose*.yml`; do printf " -f %s" "$i"; done )
+  debug "docker-compose flags: ${flags[@]}"
+  debug "docker-compose configs: ${compose_files}"
   docker-compose $(echo $compose_files) ${flags[@]}
 }
 

--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -7,7 +7,8 @@ postgresComposeService="postgres"
 function compose_client() {
   flags=($@)
   debug "executing docker-compose ${flags[@]}"
-  docker-compose -f "${PLEXTRAC_HOME}/docker-compose.yml" -f "${PLEXTRAC_HOME}/docker-compose.override.yml" ${flags[@]}
+  compose_files=$(for i in `ls docker-compose*.yml`; do printf " -f ${PLEXTRAC_HOME}/%s" "$i"; done )
+  docker-compose $(echo $compose_files) ${flags[@]}
 }
 
 function pull_docker_images() {


### PR DESCRIPTION
Will now grab the `docker-compose*.yml` of the current directory (should be `/opt/plextrac/`) and will pipe that through to the docker-compose config. This will allow us to create and manage a docker-compose.salt-managed.yml for any cloud-hosted specifics we want to set via Salt.