### PR TITLE
QUICK-692 run pg schema migrations before couchbase migrations

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -42,8 +42,8 @@ services:
     command: |
       sh -c
         "npm run maintenance:enable &&
-         npm run db:migrate &&
          npm run pg:migrate &&
+         npm run db:migrate &&
          npm run pg:etl up all &&
          npm run maintenance:disable"
     environment:


### PR DESCRIPTION
<!-- Make sure the TITLE of your PR includes the Jira issue number, i.e. PDB-123 -->
## Summary
### _What_
Changes the order of the api startup flow so that postgres schema migrations run _before_ couchbase migrations.

### _Why_
The runbooks v2 feature is built to rely on the _couchbase_ migration runner to seed data into _postgres_. While this isn't ideal, we are going to support this for now because we don't have another alternative in place for the Oaks team to use to do this data seeding at the moment. So in order for the couchbase migration runner to be able to seed data into the runbooks postgres tables, the tables will need to exist. Therefore, we now need the pg schema migrations to run before the couchbase migrations.

## Testing & Repro Steps
1. Deploy this to an environment
2. Watch the order of operations (pg schema migrations first, then cb migrations, then etl)


## Jira Issues
Please put links to the Jira issues that prompted this PR
- https://plextrac.atlassian.net/browse/QUICK-692
