### PR TITLE
Mdb/add validate postgres metrics user

### DIFF
--- a/src/_check.sh
+++ b/src/_check.sh
@@ -19,6 +19,8 @@ function mod_check() {
         msg "    %s\n" "$pending"
     fi
     VALIDATION_ONLY=1 configure_couchbase_users
+    postgres_metrics_validation
+
 
     # echo >&2 ""
 

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -102,7 +102,7 @@ BEGIN
           SELECT                       -- SELECT list can stay empty for this
           FROM   pg_catalog.pg_user
           WHERE  usename = '$PG_METRICS_USER') THEN
-    CREATE USER postgres_exporter;
+    CREATE USER $PG_METRICS_USER;
   END IF;
 END;
 \\$\\$ language plpgsql;
@@ -110,10 +110,10 @@ END;
 SELECT __tmp_create_user();
 DROP FUNCTION __tmp_create_user();
 
-ALTER USER postgres_exporter WITH PASSWORD '$PG_METRICS_PASSWORD';
-ALTER USER postgres_exporter SET SEARCH_PATH TO postgres_exporter,pg_catalog;
+ALTER USER $PG_METRICS_USER WITH PASSWORD '$PG_METRICS_PASSWORD';
+ALTER USER $PG_METRICS_USER SET SEARCH_PATH TO $PG_METRICS_USER,pg_catalog;
 
-GRANT pg_monitor to postgres_exporter;
+GRANT pg_monitor to $PG_METRICS_USER;
 EOF
 `"
 fi

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -92,7 +92,7 @@ EOINITDBSCRIPT
 }
 
 function postgres_metrics_validation() {
-  if [ -n "${PG_METRICS_USER}" ]; then
+  if [ "${PG_METRICS_USER:-}" != "" ]; then
     info "Checking user $PG_METRICS_USER can access postgres metrics"
     debug "`compose_client exec -T -u 1337 -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
         psql -a -v -U internalonly -d core 2>&1 <<- EOF 

--- a/src/plextrac
+++ b/src/plextrac
@@ -238,9 +238,9 @@ function mod_install() {
   requires_user_plextrac
   mod_configure
   mod_check
-  info "Starting Couchbase before other services"
-  compose_client up -d "$couchbaseComposeService"
-  info "Sleeping to give Couchbase a chance to start up"
+  info "Starting Databases before other services"
+  compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
+  info "Sleeping to give Databases a chance to start up"
   local progressBar
   for i in `seq 1 20`; do
     progressBar=`printf ".%.0s%s"  {1..$i} "${progressBar:-}"`
@@ -288,6 +288,9 @@ function mod_start() {
 function mod_autofix() {
   title "Fixing Auto-Correctable Issues"
   configure_couchbase_users
+  # Add postgres configuration monitor here
+  postgres_metrics_validation
+  
 }
 
 function mod_version() {

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -204,6 +204,8 @@ services:
     - postgres-initdb:/docker-entrypoint-initdb.d
     - postgres-data:/var/lib/postgresql/data
     - postgres-backups:/backups
+    ports:
+    - 5432:5432
     restart: always
 
 volumes:


### PR DESCRIPTION
- Added function to create `postgres_exporter` user in PG database; this allows scraping to be done at minimum privilege
- Exposed postgres ports to scraping (observability change)