### PR TITLE
TACO-326: Artifacts Remain on UI After Cleanup

### DIFF
--- a/src/_clean.sh
+++ b/src/_clean.sh
@@ -66,5 +66,5 @@ function clean_sweepUploadsCache() {
   info "core-backend: Cleaning uploads/exports caches"
   # Leaving the cleanup fairly light, this should help a ton without getting aggressive
   debug "`compose_client exec -T -w /usr/src/plextrac-api/uploads plextracapi \
-    find . -type f -regextype posix-extended -regex '^.*\.(json|xml|ptrac|csv|nessus)$' ! -path './etl-logs/*' -delete`"
+    find . -maxdepth 1 -type f -regextype posix-extended -regex '^.*\.(json|xml|ptrac|csv|nessus)$' -delete`"
 }


### PR DESCRIPTION
<!-- Make sure the TITLE of your PR includes the Jira issue number, i.e. PDB-123 -->
## Summary
### _What_
Artifacts remained on the UI once the `plextrac clean` function was run, however, the files couldn't be downloaded anymore due to the reference to the file within couchbase that remains after the cleanup.

### _Why_
The file isn’t actually on the disc/instance’s storage, so when someone goes to download it, the downloader looks in the storage and it can’t find it because plextrac clean deleted them.

This PR fixes this issue by not touching the `/uploads/file-manager/` directory or any other sub-directories under `uploads`

## Testing & Repro Steps
1. Navigate to a Report -> Artifacts -> upload some files such as images, .csv, .json, etc.
2. In your terminal, navigate to `localpath/product-core-backend/uploads`
3. If you have the homebrew `coreutils` and `findutils`, then good. If not, `brew install` both of those.
4. If you are reproducing the bug, enter: `gfind . -type f -regextype posix-extended -regex '^.*\.(json|xml|ptrac|csv|nessus)$' ! -path './etl-logs/*' -delete`
5. Navigate back to the Report you uploaded files to.
6. Try to download the non-image files - you should get a `400` error saying Not Found!
7. Create a new Report and repeat step 1
8. If you are reproducing the fix, enter: `gfind . -maxdepth 1 -type f -regextype posix-extended -regex '^.*\.(json|xml|ptrac|csv|nessus)$' -delete`
9. Back at the Report, try downloading your files. You should not encounter any errors.


## Jira Issues
Please put links to the Jira issues that prompted this PR
- https://plextrac.atlassian.net/browse/TACO-326