### PR TITLE
increase timeouts, silently kill progress bar and retry containers

### DIFF
--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -44,3 +44,22 @@ function docker_createInitialComposeOverrideFile() {
   fi
   log "Done"
 }
+
+function checkFailedContainers() {
+  # check current status of containers and restart any that show exited (1), created or unhealthy
+  # if that's found, run the update again
+  if [ `compose_client ps | egrep 'exited \(1\)|unhealthy|created'` ]; then
+    info "An error occured with one or more containers, attempting to start again"
+    # sleep for 5 to give things a moment to settle, then try starting again
+    sleep 5
+    mod_start
+    # check again, then throw an error if containers are still in a bad state
+    if [ `compose_client ps | egrep 'exited \(1\)|unhealthy|created'` ]; then
+      error "One or more containers are in a failed state, please contact support!"
+      return 1
+    fi
+  else
+    debug "no failed containers found, continuing"
+    return 0
+  fi
+}

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -23,6 +23,7 @@ function mod_update() {
   pull_docker_images
   mod_start
   mod_check
+  checkFailedContainers
 }
 
 function _selfupdate_refreshReleaseInfo() {

--- a/src/plextrac
+++ b/src/plextrac
@@ -277,13 +277,13 @@ function mod_start() {
   # it should take an optional param which is a function
   # that should return 0 when ready
   (
-    for i in `seq 1 30`; do
+    for i in `seq 1 60`; do
       progressBar=`printf ".%.0s%s"  {1..$i} "${progressBar:-}"`
       msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
       sleep 2
     done &
-    timeout --preserve-status 60 docker wait "$(compose_client ps couchbase-migrations -q)" >/dev/null || { error "Migrations exceeded timeout"; exitStatus=1; }
-    kill $!; trap 'kill $!' SIGTERM
+    timeout --preserve-status 300 docker wait "$(compose_client ps couchbase-migrations -q)" >/dev/null || { error "Migrations exceeded timeout"; exitStatus=1; }
+    ps $! >/dev/null 2>&1 && kill $! >/dev/null 2>&1; trap 'kill $!' SIGTERM
     >&2 echo -n "${RESET}"
     if [ "${exitStatus:-0}" -ne 0 ]; then
       return "$exitStatus"


### PR DESCRIPTION
**Background**
Small tweaks to handle new instances since they take a long time to run migrations.
Also adds a retry for failed containers to help auto recover on updates.
**Impact**
No errors thrown if the progress bar exits before migrations container does.
Attempts to start containers again if any of them are in a failed state `exited (1)|unhealthy|created` and then throws an error if the issue persists.
**Risk**
An unknown bug could prevent updates or correct installs
**Testing**
1. Tested in a vagrant environment with fresh installs. 
Progress bar finishes running, but the program continues to wait for migration container to finish. Kill task attempts to kill progress bar, but silently fails because the PID no longer exists. Result now is  long progress bar, followed by `done`