### PR TITLE
QS-279 Pull the PG_MIGRATE_TENANT env var into the couchbase-migrations service definition

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       PG_RUNBOOKS_DB: ${PG_RUNBOOKS_DB:?err}
       PG_TENANTS_WRITE_MODE: ${PG_TENANTS_WRITE_MODE:-couchbase_only}
       PG_TENANTS_READ_MODE: ${PG_TENANTS_READ_MODE:-couchbase_only}
+      PG_MIGRATE_TENANT: ${PG_MIGRATE_TENANT} # Default value defined in app code
 
   plextracdb:
     environment:


### PR DESCRIPTION
WHAT:
Makes the new env var `PG_MIGRATE_TENANT` available to the `couchbase-migrations` service container.
(The `plextracapi` service also uses this env var, but that service pulls the entire .env file into the environment so we don't need to explicitly update docker-compose file to mention it).

WHY:
Quicksilver is building the new fault-tolerant ETL-runner, which will no longer require 2 env vars per domain (i.e. PG_TENANT_READ_MODE and PG_TENANT_WRITE_MODE). This PR puts the new, single env var into place that will replace them (PG_MIGRATE_TENANT)

There's [another PR here](https://github.com/PlexTrac/infra-saltstack/pull/128) in the SaltStack repo that will ensure that all cloud-hosted environments have this env var in their `.env` file.