### PR TITLE
Added Maintenance Mode Check

### DIFF
--- a/src/_check.sh
+++ b/src/_check.sh
@@ -20,6 +20,7 @@ function mod_check() {
     fi
     VALIDATION_ONLY=1 configure_couchbase_users
     postgres_metrics_validation
+    check_for_maintenance_mode
 
 
     # echo >&2 ""
@@ -27,6 +28,18 @@ function mod_check() {
     # title "Notifications"
     # info "Summary"
     # msg "`compose_client exec plextracapi npm run status:notifications | fgrep -v '> '`"
+  fi
+}
+function check_for_maintenance_mode() {
+  title "Checking Maintenance Mode"
+  IN_MAINTENANCE="null"
+  IN_MAINTENANCE=$(curl -ks https://${CLIENT_DOMAIN_NAME}/api/v2/health/full | jq .data.inMaintenanceMode)
+  if [ $IN_MAINTENANCE == "true" ]; then
+    info "Maintenance Mode: $IN_MAINTENANCE"
+  elif [ $IN_MAINTENANCE == "false" ]; then
+    info "Maintenance Mode: $IN_MAINTENANCE"
+  else
+    info "Maintenance Mode: Error"
   fi
 }
 

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -30,6 +30,9 @@ function mod_info() {
   info "Disk Statistics"
   msg `check_disk_capacity`
   msg `info_backupDiskUsage`
+
+  #Check for Maintenance Mode
+  msg `check_for_maintenance_mode`
 }
 
 function info_TLSCertificateDetails() {


### PR DESCRIPTION
- Modified the _check.sh and _info.sh files to include a new function to curl the `${CLIENT_DOMAIN_NAME}/api/v2/health/full` endpoint and return current maintenance mode status