### PR TITLE
Set Postgres port to bind only on localhost

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -243,7 +243,7 @@ services:
     - postgres-data:/var/lib/postgresql/data
     - postgres-backups:/backups
     ports:
-    - 5432:5432
+    - 127.0.0.1:5432:5432/tcp
     restart: always
 
 volumes:


### PR DESCRIPTION
## Background

We opened up this port so we could get metrics, but missed in review that this binds to _all_ ports.

## Impact

Makes the Postgres port only bind on _localhost_

## Risk

Will cause a Postgres restart when this applies

## Testing

Run an update with this version and observe postgres is bound only to localhost