### PR TITLE
QS-308 pg restore retain ownership

### DIFF
--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -76,8 +76,10 @@ function restore_doPostgresRestore() {
       log "Extracting backup for $db"
       debug "`compose_client exec -T $postgresComposeService\
         tar -xvzf /backups/$backupFile ./$db.psql 2>&1`"
-      log "Restoring $db"
-      dbRestoreFlags="-d $db --clean --if-exists --disable-triggers --verbose"
+      dbAdminEnvvar="PG_${db^^}_ADMIN_USER"
+      dbAdminRole=$(eval echo "\$$dbAdminEnvvar")
+      log "Restoring $db with role:${dbAdminRole}"
+      dbRestoreFlags="-d $db --clean --if-exists --no-privileges --no-owner --role=$dbAdminRole  --disable-triggers --verbose"
       debug "`compose_client exec -T -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
         pg_restore -U $POSTGRES_USER $dbRestoreFlags ./$db.psql 2>&1`"
       debug "`compose_client exec -T $postgresComposeService \

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -77,7 +77,7 @@ function restore_doPostgresRestore() {
       debug "`compose_client exec -T $postgresComposeService\
         tar -xvzf /backups/$backupFile ./$db.psql 2>&1`"
       log "Restoring $db"
-      dbRestoreFlags="-d $db --clean --if-exists --no-owner --disable-triggers --verbose"
+      dbRestoreFlags="-d $db --clean --if-exists --disable-triggers --verbose"
       debug "`compose_client exec -T -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
         pg_restore -U $POSTGRES_USER $dbRestoreFlags ./$db.psql 2>&1`"
       debug "`compose_client exec -T $postgresComposeService \


### PR DESCRIPTION
## Overview
Fixes a bug where taking a postgres backup and then restoring that backup will cause future pg schema migrations to fail because the ownership of the tables will be wrong. Our schema migration runner expects that the individual db admin users will be owners of the tables, but after performing a pg restore the pg super user is the owner instead.

This PR fixes this by removing the CLI flag that was causing the table ownership to be ignored when performing the pg_restore.

## Steps to reproduce
1. Take a backup: `plextrac backup`
2. Restore that backup: `plextrac restore`
3. Shell into the pg container: `docker-compose exec postgres /bin/bash`
4. Open a psql connection: `PGPASSWORD=$PG_CORE_ADMIN_PASSWORD psql -U $PG_CORE_ADMIN_USER core`
5. Check the table owner: `\dt`

**Buggy behavior**
```
                 List of relations
 Schema |        Name        | Type  |    Owner     
--------+--------------------+-------+--------------
 public | tenant             | table | internalonly
```

**Correct behavior**
```
                List of relations
 Schema |        Name        | Type  |   Owner    
--------+--------------------+-------+------------
 public | tenant             | table | core_admin
```
