### PR TITLE
QS-229 add etl status to 'plextrac check' command

### DIFF
--- a/src/_check.sh
+++ b/src/_check.sh
@@ -130,7 +130,7 @@ function _check_base_required_packages() {
 }
 
 function check_etl_status() {
-  title "Checking CB->PG ETL status"
+  title "Checking Couchbase-to-Postgres ETL status"
 
   RAW_OUTPUT=$(`compose_client exec plextracapi npm run pg:etl:status`)
 


### PR DESCRIPTION
Testing steps to come soonTM


## Example Output
**Note: the raw json only prints if you pass `-v` as a cli flag**

```
plextrac check -v

<output from other checks omitted>

-- Checking CB->PG ETL status --------------------------------------------------

!!! One or more ETLs are in an unhealthy status.

    Domains (Read Mode / Write Mode):
      authentication: couchbase_only / couchbase_only
                 ctf: couchbase_only / couchbase_only
              tenant: couchbase_only / couchbase_only
      tenantSettings: couchbase_only / couchbase_only
                user: couchbase_only / couchbase_only
    ETLs:
      etl_tenant_v1: UNKNOWN
      etl_user_v1: SUCCESS

    {
      "domains": {
        "authentication": {
          "featureGateName": "PG_MIGRATE_USER",
          "featureGateStatus": "disabled",
          "etlStatus": {},
          "readMode": "couchbase_only",
          "writeMode": "couchbase_only"
        },
        "ctf": {
          "featureGateName": "PG_MIGRATE_USER",
          "featureGateStatus": "disabled",
          "etlStatus": {},
          "readMode": "couchbase_only",
          "writeMode": "couchbase_only"
        },
        "tenant": {
          "featureGateName": "PG_MIGRATE_TENANT",
          "featureGateStatus": "enabled",
          "etlStatus": {
            "etl_tenant_v1": "UNKNOWN"
          },
          "readMode": "couchbase_only",
          "writeMode": "couchbase_only"
        },
        "tenantSettings": {
          "featureGateName": "PG_MIGRATE_TENANT",
          "featureGateStatus": "enabled",
          "etlStatus": {
            "etl_tenant_v1": "UNKNOWN"
          },
          "readMode": "couchbase_only",
          "writeMode": "couchbase_only"
        },
        "user": {
          "featureGateName": "PG_MIGRATE_USER",
          "featureGateStatus": "disabled",
          "etlStatus": {},
          "readMode": "couchbase_only",
          "writeMode": "couchbase_only"
        }
      },
      "etls": {
        "etl_tenant_v1": {
          "status": "UNKNOWN",
          "error": "Could not read etl result file."
        },
        "etl_user_v1": {
          "status": "SUCCESS",
          "error": "Could not read etl result file."
        }
      },
      "etlsCombinedStatus": "HEALTHaY"
    }
```
