### PR TITLE
Fix for failing `plextrac install` command

### DIFF
--- a/src/_check.sh
+++ b/src/_check.sh
@@ -33,15 +33,9 @@ function mod_check() {
 }
 function check_for_maintenance_mode() {
   title "Checking Maintenance Mode"
-  IN_MAINTENANCE="null"
-  IN_MAINTENANCE=$(curl -ks https://${CLIENT_DOMAIN_NAME}/api/v2/health/full | jq .data.inMaintenanceMode) || IN_MAINTENANCE="null"
-  if [ $IN_MAINTENANCE == "true" ]; then
-    info "Maintenance Mode: $IN_MAINTENANCE"
-  elif [ $IN_MAINTENANCE == "false" ]; then
-    info "Maintenance Mode: $IN_MAINTENANCE"
-  else
-    info "Maintenance Mode: Error"
-  fi
+  IN_MAINTENANCE="Unknown"
+  IN_MAINTENANCE=$(curl -ks https://${CLIENT_DOMAIN_NAME}/api/v2/health/full | jq .data.inMaintenanceMode) || IN_MAINTENANCE="Unknown"
+  info "Maintenance Mode: $IN_MAINTENANCE"
 }
 
 ###

--- a/src/_check.sh
+++ b/src/_check.sh
@@ -18,11 +18,9 @@ function mod_check() {
         error "Pending Changes:"
         msg "    %s\n" "$pending"
     fi
-    if [ ${INSTALL_ONLY:-0} -eq 0 ]; then
-      VALIDATION_ONLY=1 configure_couchbase_users
-      postgres_metrics_validation
-      check_for_maintenance_mode
-    fi
+    VALIDATION_ONLY=1 configure_couchbase_users
+    postgres_metrics_validation
+    check_for_maintenance_mode
 
     # echo >&2 ""
 

--- a/src/_check.sh
+++ b/src/_check.sh
@@ -31,7 +31,6 @@ function mod_check() {
 }
 function check_for_maintenance_mode() {
   title "Checking Maintenance Mode"
-  IN_MAINTENANCE="Unknown"
   IN_MAINTENANCE=$(curl -ks https://${CLIENT_DOMAIN_NAME}/api/v2/health/full | jq .data.inMaintenanceMode) || IN_MAINTENANCE="Unknown"
   info "Maintenance Mode: $IN_MAINTENANCE"
 }

--- a/src/_check.sh
+++ b/src/_check.sh
@@ -18,10 +18,11 @@ function mod_check() {
         error "Pending Changes:"
         msg "    %s\n" "$pending"
     fi
-    VALIDATION_ONLY=1 configure_couchbase_users
-    postgres_metrics_validation
-    check_for_maintenance_mode
-
+    if [ ${INSTALL_ONLY:-0} -eq 0 ]; then
+      VALIDATION_ONLY=1 configure_couchbase_users
+      postgres_metrics_validation
+      check_for_maintenance_mode
+    fi
 
     # echo >&2 ""
 
@@ -33,7 +34,7 @@ function mod_check() {
 function check_for_maintenance_mode() {
   title "Checking Maintenance Mode"
   IN_MAINTENANCE="null"
-  IN_MAINTENANCE=$(curl -ks https://${CLIENT_DOMAIN_NAME}/api/v2/health/full | jq .data.inMaintenanceMode)
+  IN_MAINTENANCE=$(curl -ks https://${CLIENT_DOMAIN_NAME}/api/v2/health/full | jq .data.inMaintenanceMode) || IN_MAINTENANCE="null"
   if [ $IN_MAINTENANCE == "true" ]; then
     info "Maintenance Mode: $IN_MAINTENANCE"
   elif [ $IN_MAINTENANCE == "false" ]; then

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -138,6 +138,19 @@ function updateComposeConfig() {
   info "Done."
 }
 
+function validateComposeConfig() {
+  info "Checking Docker Compose Config"
+  composeConfigCheck=$(compose_client config -q 2>&1 || true)
+  if [ $composeConfigCheck != "" ]; then
+    error "Invalid Docker Compose Configuration"
+    msg "Please check for valid syntax in override files"
+    debug "$composeConfigCheck"
+    return 1
+  else
+    info "Config check passed"
+  fi
+}
+
 function create_volume_directories() {
   title "Create directories for bind mounts"
   debug "Ensuring directories exist for Docker Volumes..."

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -139,15 +139,15 @@ function updateComposeConfig() {
 }
 
 function validateComposeConfig() {
-  info "Checking Docker Compose Config"
-  composeConfigCheck=$(compose_client config -q 2>&1 || true)
-  if [ $composeConfigCheck != "" ]; then
+  info "Validating Docker Compose Config"
+  composeConfigCheck=$(compose_client config -q 2>&1) || configValidationFailed=1
+  if [ ${configValidationFailed:-0} -ne 0 ]; then
     error "Invalid Docker Compose Configuration"
-    msg "Please check for valid syntax in override files"
+    log "Please check for valid syntax in override files"
     debug "$composeConfigCheck"
     return 1
   else
-    info "Config check passed"
+    log "Docker Compose Syntax Valid"
   fi
 }
 

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -27,7 +27,7 @@ function mod_info() {
   echo >&2 ""
 
   #Check for Maintenance Mode
-  msg check_for_maintenance_mode
+  check_for_maintenance_mode
 
   title "Host Details"
   info "Disk Statistics"

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -26,13 +26,14 @@ function mod_info() {
   msg "    %s\n" "$active"
   echo >&2 ""
 
+  #Check for Maintenance Mode
+  msg `check_for_maintenance_mode`
+
   title "Host Details"
   info "Disk Statistics"
   msg `check_disk_capacity`
   msg `info_backupDiskUsage`
 
-  #Check for Maintenance Mode
-  msg `check_for_maintenance_mode`
 }
 
 function info_TLSCertificateDetails() {

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -27,7 +27,7 @@ function mod_info() {
   echo >&2 ""
 
   #Check for Maintenance Mode
-  msg `check_for_maintenance_mode`
+  msg check_for_maintenance_mode
 
   title "Host Details"
   info "Disk Statistics"

--- a/src/plextrac
+++ b/src/plextrac
@@ -239,11 +239,6 @@ function mod_install() {
   mod_configure
   info "Checking Docker Compose Config"
   compose_client config -q && info "Config check passed"
-  pending=`composeConfigNeedsUpdated || true`
-  if [ "$pending" != "" ]; then
-      error "Pending Changes:"
-      msg "    %s\n" "$pending"
-  fi
   info "Starting Databases before other services"
   compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
   info "Sleeping to give Databases a chance to start up"

--- a/src/plextrac
+++ b/src/plextrac
@@ -237,7 +237,13 @@ function mod_install() {
   title "Installing PlexTrac Instance"
   requires_user_plextrac
   mod_configure
-  INSTALL_ONLY=1 mod_check
+  info "Checking Docker Compose Config"
+  compose_client config -q && info "Config check passed"
+  pending=`composeConfigNeedsUpdated || true`
+  if [ "$pending" != "" ]; then
+      error "Pending Changes:"
+      msg "    %s\n" "$pending"
+  fi
   info "Starting Databases before other services"
   compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
   info "Sleeping to give Databases a chance to start up"

--- a/src/plextrac
+++ b/src/plextrac
@@ -237,8 +237,6 @@ function mod_install() {
   title "Installing PlexTrac Instance"
   requires_user_plextrac
   mod_configure
-  info "Checking Docker Compose Config"
-  compose_client config -q && info "Config check passed"
   info "Starting Databases before other services"
   compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
   info "Sleeping to give Databases a chance to start up"
@@ -262,6 +260,7 @@ function mod_configure() {
   generate_default_config
   login_dockerhub
   updateComposeConfig
+  validateComposeConfig
   create_volume_directories
   deploy_volume_contents_postgres
 }

--- a/src/plextrac
+++ b/src/plextrac
@@ -302,9 +302,9 @@ function mod_start() {
 
 function mod_autofix() {
   title "Fixing Auto-Correctable Issues"
+  configure_couchbase_users
   # Add postgres configuration monitor here
   postgres_metrics_validation
-  configure_couchbase_users
 }
 
 function mod_version() {

--- a/src/plextrac
+++ b/src/plextrac
@@ -237,7 +237,7 @@ function mod_install() {
   title "Installing PlexTrac Instance"
   requires_user_plextrac
   mod_configure
-  mod_check
+  INSTALL_ONLY=1 mod_check
   info "Starting Databases before other services"
   compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
   info "Sleeping to give Databases a chance to start up"
@@ -302,10 +302,9 @@ function mod_start() {
 
 function mod_autofix() {
   title "Fixing Auto-Correctable Issues"
-  configure_couchbase_users
   # Add postgres configuration monitor here
   postgres_metrics_validation
-  
+  configure_couchbase_users
 }
 
 function mod_version() {


### PR DESCRIPTION
- Added logic on `plextrac install` command to limit user validation inside DBs until after they are started
- Moved Maintenance mode check in `plextrac info` command to make more sense