### PR TITLE
added post installation message for historical logging

### DIFF
--- a/src/plextrac
+++ b/src/plextrac
@@ -253,6 +253,10 @@ function mod_install() {
   pull_docker_images
   mod_start 360 # allow up to 6 minutes for startup on install, due to migrations
   mod_info
+  info "Post installation note:"
+  log "If you wish to have access to historical logs, you can configure docker to send logs to journald."
+  log "Please see the config steps at"
+  log "https://docs.plextrac.com/plextrac-documentation/product-documentation-1/on-premise-management/setting-up-historical-logs"
 }
 
 function mod_configure() {


### PR DESCRIPTION
## Background
A frequent question from on-prem users is how to get historical logs from the app. CS has written external documentation outlining the configuration steps. This update adds a post installation note with a link to this documentation.

## Impact
Additional output from manager util upon installation.

## Risk
Minimal, only change is additional console output.

## Testing
Fresh install on a VM to validate formatting, syntax and appearance. Outputs at the end of install and not an update. Below is what is printed:

```
[+] Post installation note:
    If you wish to have access to historical logs, you can configure docker to send logs to journald.
    Please see the config steps at
    https://docs.plextrac.com/plextrac-documentation/product-documentation-1/on-premise-management/setting-up-historical-logs
```