### PR TITLE
COMING-500N Added the localesOverride volume mount for the plextracapi container

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     volumes:
     - uploads:/usr/src/plextrac-api/uploads:rw
     - datalake-maintainer-keys:/usr/src/plextrac-api/keys/gcp:r
+    - localesOverride:/usr/src/plextrac-api/localesOverride:rw
     healthcheck:
       test:
       # Handle cURL being removed due to upstream vuln
@@ -250,6 +251,7 @@ volumes:
   dbdata: {}
   uploads: {}
   letsencrypt: {}
+  localesOverride: {}
   postgres-data: {}
   postgres-initdb:
     driver: local


### PR DESCRIPTION
## What
Added the `localesOverride` volume mount to the `plextracapi` container in the docker-compose.yml file


## Why
When a new customer instance is provisioned, the `localesOverride` volume mount is manually added to the `docker-compose.override.yml` file after terraform creates the instance.  This is currently being done for all new customer instances. 
 By adding the volume mount to the base `docker-compose` file, a manual step can be eliminated from the provisioning process.
Requested by Michael Bailey during a shadowing session.

There's an ongoing debate about whether white-labeling should be used at all - Slack conversation: https://plextrac.slack.com/archives/C02BSEY93T5/p1677538604353329
