### PR TITLE
Use a temporary volume for uploads backup

### DIFF
--- a/src/_backup.sh
+++ b/src/_backup.sh
@@ -23,9 +23,9 @@ function backup_fullUploadsBackup() {
   info "$coreBackendComposeService: Performing backup of uploads directory"
   uploadsBackupDir="${PLEXTRAC_BACKUP_PATH}/uploads"
   mkdir -p $uploadsBackupDir
-  debug "`compose_client run --workdir /usr/src/plextrac-api --rm --entrypoint='' -T \
-    $coreBackendComposeService tar -czf - uploads > \
-    ${uploadsBackupDir}/$(date -u "+%Y-%m-%dT%H%M%Sz").tar.gz`"
+  debug "`compose_client run --user 1337 -v ${uploadsBackupDir}:/backups \
+    --workdir /usr/src/plextrac-api --rm --entrypoint='' -T  $coreBackendComposeService \
+    tar -czf /backups/$(date -u "+%Y-%m-%dT%H%M%Sz").tar.gz uploads`"
   log "Done."
 }
 


### PR DESCRIPTION
## Background

This is some old logic that is super inefficient and was triggering some false alarms in monitoring. Simple change to avoid some extra filtering we have to do and make our security team less twitchy.

## Impact

Minor change to the mechanics of taking a backup with no change to outputs

## Risk

N/a

## Testing

Run a backup `/vagrant/src/plextrac backup -v` and validate the correct command is used and backup structure is present.