### PR TITLE
Adds nginx healthcheck and corrects startup check to use case insensitive match

### DIFF
--- a/src/_update.sh
+++ b/src/_update.sh
@@ -28,14 +28,14 @@ function mod_update() {
     mod_start
 
     # Check for failed containers and continue in loop if any are found, otherwise break out of loop
-    compose_client ps | egrep 'exited \(1\)|unhealthy|created' >/dev/null || break
+    compose_client ps | egrep -i 'exited \(1\)|unhealthy|created|starting' >/dev/null || break
 
     if [[ $i -ge $maxRetries ]]; then
       error "One or more containers are in a failed state, please contact support!"
       exit 1
     fi
 
-    info "An error occured with one or more containers, attempting to start again"
+    info "An error occurred with one or more containers, attempting to start again"
     sleep 5
 
   done

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -112,6 +112,13 @@ services:
     restart: always
     volumes:
     - letsencrypt:/etc/letsencrypt:rw
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - 'echo "GET /" | openssl s_client -quiet -connect localhost:443'
+      interval: 5s
+      retries: 8
+      start_period: 5s
 
   notification-engine:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"


### PR DESCRIPTION
## Background

We occasionally see updates "complete" but Docker Compose has only _created_ the container. This change ensures that scenario is detected, and further enables health checks to ensure the nginx proxy has started up and is able to negotiate SSL connections

## Impact

Will cause the nginx proxy container to be recreated and adds health check

## Risk

Low, the health check works with self signed certificates and largely exists just to ensure the startup script has completed.

## Testing

Tested in vagrant with self signed cert and evaluated scenarios:
- Invalid container config (causing a restart loop)
- Unable to retrieve LetsEncrypt cert (unable to setup SSL connection)
- Connection failure (specified bad port)