### PR TITLE
Adds support for restoring from backups during the install

### DIFF
--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -32,6 +32,9 @@ function restore_doUploadsRestore() {
 
 function restore_doCouchbaseRestore() {
   title "Restoring Couchbase from backup"
+  debug "Fixing permissions"
+  debug "`compose_client exec -T $couchbaseComposeService \
+    chown -R 1337:1337 /backups 2>&1`"
   latestBackup="`ls -dc1 ${PLEXTRAC_BACKUP_PATH}/couchbase/* | head -n1`"
   backupFile=`basename $latestBackup`
   info "Latest backup: $latestBackup"
@@ -47,7 +50,7 @@ function restore_doCouchbaseRestore() {
 
     log "Running database restore"
     compose_client exec $couchbaseComposeService cbrestore /backups http://localhost:8091 \
-      -u ${CB_BACKUP_USER} -p "${CB_BACKUP_PASS}" -x conflict_resolve=0,data_only=1
+      -u ${CB_BACKUP_USER} -p "${CB_BACKUP_PASS}" --from-date 2022-01-01 -x conflict_resolve=0,data_only=1
 
     log "Cleaning up extracted backup files"
     dirName=`basename -s .tar.gz $backupFile`

--- a/src/plextrac
+++ b/src/plextrac
@@ -144,6 +144,11 @@ function main() {
         FORCEUPGRADE="force"
         shift
         ;;
+      # Enable restoring during installation (before migrations)
+      "--restore")
+        RESTOREONINSTALL=1
+        shift
+        ;;
       # Enable restoring a specific target
       "--restore-only")
         RESTORETARGET=$2
@@ -249,6 +254,20 @@ function mod_install() {
   >&2 echo -n "${RESET}"
   log "Done"
   mod_autofix
+  if [ ${RESTOREONINSTALL:-0} -eq 1 ]; then
+    info "Restoring from backups"
+    log "Restoring databases first"
+    RESTORETARGET="couchbase" mod_restore
+    if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/postgres/)" ]; then
+      RESTORETARGET="postgres" mod_restore
+    fi
+    if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/uploads/)" ]; then
+      log "Starting API to prepare for uploads restore"
+      compose_client up -d "$coreBackendComposeService"
+      log "Restoring uploads"
+      RESTORETARGET="uploads" mod_restore
+    fi
+  fi
   pull_docker_images
   mod_start 360 # allow up to 6 minutes for startup on install, due to migrations
   mod_info


### PR DESCRIPTION
## Background

Data restoration is important and stuff. Also it sucks to be slow.

## Impact

Allows smoother restores by handling the data restore during the install step. This reduces extra manual commands that have to be run, and handles large datasets more easily as the indexes do not yet exist.

## Risk

Low, the capability is behind a flag that is not documented so this is additive and not disruptive to current workflows.

## Testing

I tested in a local vagrant environment, with a backup I had available (couchbase only, I constructed a fake uploads backup as well). I verified that the correct files are restored, the appropriate containers exist _prior_ to running the restore, postgres/uploads are optional.