### PR TITLE
Adds a workaround to cbrestore blowing chunks when running a restore non-interactively

### DIFF
--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -49,7 +49,9 @@ function restore_doCouchbaseRestore() {
       tar -xzvf /backups/$backupFile 2>&1`"
 
     log "Running database restore"
-    compose_client exec $couchbaseComposeService cbrestore /backups http://localhost:8091 \
+    # We have the TTY enabled by default so the output from cbrestore is intelligible
+    tty -s || { debug "Disabling TTY allocation for Couchbase restore due to non-interactive invocation"; ttyFlag="-T"; }
+    compose_client exec ${ttyFlag:-} $couchbaseComposeService cbrestore /backups http://localhost:8091 \
       -u ${CB_BACKUP_USER} -p "${CB_BACKUP_PASS}" --from-date 2022-01-01 -x conflict_resolve=0,data_only=1
 
     log "Cleaning up extracted backup files"


### PR DESCRIPTION
Tested using local vagrant, as well as "live" on a dev box using a manually edited script. Both normal and non-interactive modes work (eg, SSH and saltstack invocation)

```shell
vagrant ssh -c "sudo -i -u plextrac /vagrant/src/plextrac restore -y -v" -- -T
```

![Screenshot from 2023-04-26 17-41-24](https://user-images.githubusercontent.com/4613566/234725413-7190b52a-df81-4b43-9947-a135fd343c8b.png)