### PR TITLE
PG-99: Add env var

### DIFF
--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -28,6 +28,7 @@ function generate_default_config() {
 
   # Generate base env, using imported vars from above where applicable
   generatedEnv="
+API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE=${API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE:-`generateSecret`}
 JWT_KEY=${JWT_KEY:-`generateSecret`}
 MFA_KEY=${MFA_KEY:-`generateSecret`}
 COOKIE_KEY=${COOKIE_KEY:-`generateSecret`}

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -135,9 +135,7 @@ services:
       LOG_LEVEL: "${LOG_LEVEL:-info}"
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
-    # Specifically needs the API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE generated in src/_configure_plextrac.sh
-    env_file:
-    - .env
+      API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE: "${API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE:?err}"
     healthcheck:
       test:
       - "CMD"

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -135,6 +135,9 @@ services:
       LOG_LEVEL: "${LOG_LEVEL:-info}"
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
+    # Specifically needs the API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE generated in src/_configure_plextrac.sh
+    env_file:
+    - .env
     healthcheck:
       test:
       - "CMD"


### PR DESCRIPTION
## What
This adds the API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE env var to the config generator. It also gives the notification engine access to the .env file so that it can access this variable. 

## Why
This will allow inter-service network requests and is necessary to decouple the notification engine from couchbase in preparation for postgres.