### PR TITLE
Allow using current version of docker-compose

### DIFF
--- a/src/_setup_packages.sh
+++ b/src/_setup_packages.sh
@@ -116,7 +116,7 @@ function install_docker() {
 function install_docker_compose() {
   info "upgrading docker-compose..."
   curl -sL $(curl -sL \
-    https://api.github.com/repos/docker/compose/releases/tags/v2.2.3 | jq -r \
+    https://api.github.com/repos/docker/compose/releases/latest | jq -r \
     ".assets[] | select(.name | test(\"^docker-compose-$(uname -s)-$(uname -m)$\"; \"i\")) | .browser_download_url" | grep -v .sha256) -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
   docker_compose_version=`/usr/local/bin/docker-compose --version`


### PR DESCRIPTION
This reverts a pin we'd previously placed due to a bug in an earlier version of docker-compose. This will only affect _new_ installations, as the install only runs during `plextrac init`.

I tested our workflows including instance setup (from scratch) and this update looks good to go.