### PR TITLE
PG-77 Added a volume for localesOverride (to support white-labeling)

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     volumes:
     - uploads:/usr/src/plextrac-api/uploads:rw
     - datalake-maintainer-keys:/usr/src/plextrac-api/keys/gcp:r
+    - localesOverride:/usr/src/plextrac-api/localesOverride:rw
     healthcheck:
       test:
       # Handle cURL being removed due to upstream vuln
@@ -258,6 +259,7 @@ volumes:
   dbdata: {}
   uploads: {}
   letsencrypt: {}
+  localesOverride: {}
   postgres-data: {}
   postgres-initdb:
     driver: local


### PR DESCRIPTION
<h1>What</h1>
<details open="true">
  <summary>
Added `localesOverride` volume to the `plextracapi` container.

  </summary>
<h1>Why</h1>
This volume allows the "white-labeling" feature to persist changes between container restarts.  

This is <b><i>part of the change</i></b> necessary to eliminate the need for the CS team to manually update new PlexTrac instances to enable the "White Labeling" feature.

Prior to this change, the CS team needed to manually apply these changes to every new PlexTrac environment:

https://plextrac.atlassian.net/wiki/spaces/CE/pages/2330820609/Whitelabeling+-+Cannot+Wrap+An+Error

Manual process TLDR;

1. Create the plextracapi/localesOverride/en folder
2. Update the docker-compose.override.yml file to use that folder as the source of a new volume mount to store user-defined labels for things like "Clients" (which is implemented using an i18n library)

- This PR takes care of step 2.
- Step 1 is handled in this other (MERGED) PR in the product-core-backend repo: https://github.com/PlexTrac/product-core-backend/pull/3528
</details>