### PR TITLE
Install timeout increase+flag and start progress bar fix

### DIFF
--- a/src/plextrac
+++ b/src/plextrac
@@ -93,6 +93,7 @@ function mod_help() {
   log " -v | --verbose                      ${DIM}enables verbose output, helpful for troubleshooting errors${RESET}"
   log " -y | --assume-yes                   ${DIM}assumes yes to all questions in script${RESET}"
   log " --install-dir | --plextrac-home     ${DIM}path to non-standard install directory. The default is /opt/plextrac${RESET}"
+  log " --install-timeout NUM               ${DIM}seconds to wait for install migrations to complete. The default is 600 (10 mins)${RESET}"
 }
 
 
@@ -163,6 +164,12 @@ function main() {
         ;;
       "-s" | "--service")
         LOG_SERVICE=${2-''}
+        shift
+        shift
+        ;;
+      # only used for mod_install
+      "--install-timeout")
+        INSTALL_WAIT_TIMEOUT=$2
         shift
         shift
         ;;
@@ -276,7 +283,7 @@ function mod_install() {
     fi
   fi
   pull_docker_images
-  mod_start 480 # allow up to 8 minutes for startup on install, due to migrations
+  mod_start "${INSTALL_WAIT_TIMEOUT:-600}" # allow up to 10 or specified minutes for startup on install, due to migrations
   mod_info
   info "Post installation note:"
   log "If you wish to have access to historical logs, you can configure docker to send logs to journald."

--- a/src/plextrac
+++ b/src/plextrac
@@ -316,7 +316,7 @@ function mod_start() {
   # that should return 0 when ready
   (
     while true; do
-      progressBar=`printf ".%.0s%s"  {1..$i} "${progressBar:-}"`
+      progressBar=$(printf ".%s" "${progressBar:-}")
       msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
       sleep 2
     done &


### PR DESCRIPTION
I am not sure if y'all even want any or all of this, but I humbly provide it none the less. 

---

### Increase `plextrac install` start timeout to 10 mins and add an `--install-timeout` flag

#### Problem demo - I hit a timeout with the 8 minute default
<details>
Its disgusting Ansible output, I know, sorries.
<img width="1139" alt="Screen Shot 2023-08-16 at 19 41 06" src="https://github.com/PlexTrac/plextrac-manager-util/assets/14808878/47992f41-443f-408c-b879-a16d3b5f7241">
</details>

#### Solution
My initial solution was only to add the `--install-timeout NUM` flag, and then I stumbled across [this comment which implied y'all were thinking of bumping it to 10 mins anyways](https://github.com/PlexTrac/plextrac-manager-util/pull/49/files#r1043951687) soooo I did both. 

#### Testing

- [x] `plextrac install` now defaults to 600 seconds
    <details>
    <img width="792" alt="Screen Shot 2023-08-16 at 22 54 06" src="https://github.com/PlexTrac/plextrac-manager-util/assets/14808878/3cef3f79-b972-4a6e-b186-75eac0e49770">
    </details>
    
- [x] `plextrac install --install-timeout 660` overrides new default
    <details>
    <img width="1020" alt="Screen Shot 2023-08-16 at 23 00 47" src="https://github.com/PlexTrac/plextrac-manager-util/assets/14808878/b49fc719-b16e-4321-ba98-399583b57376">
    </details>

#### Documentation update
- [x] `plextrac help` now includes `--install-timeout NUM` guidance
    <details>
    <img width="953" alt="Screen Shot 2023-08-16 at 22 56 30" src="https://github.com/PlexTrac/plextrac-manager-util/assets/14808878/7b3c5ebe-9075-464b-87aa-6d79d18f97a9">
    </details>

---

### Fix `plextrac start` progress bar

#### Problem demo 

At some point there was a change from `for i in 'seq 1 30'` to `while true`, and so the `printf` was no longer valid. 
<details>
<img width="858" alt="Screen Shot 2023-08-16 at 20 57 43" src="https://github.com/PlexTrac/plextrac-manager-util/assets/14808878/9a5aede4-bd39-42a0-9147-38899f0ccddd">
</details>

#### Solution
I removed the range as a parameter for the `printf`. NGL I'm not entirely sure what that format was trying to define so I just simplified it a little and it worked sooooo.....

#### Testing

- [x] `plextrac start` now has a progress bar
    <details>
    <img width="1018" alt="Screen Shot 2023-08-16 at 23 23 04" src="https://github.com/PlexTrac/plextrac-manager-util/assets/14808878/9d272f87-df36-4446-9939-22db802d0956">
    </details>
    
---

### Linting

- [x] `shellcheck` reported less errors and no new errors, but there are definitely still errors. That might just be my next PR