### PR TITLE
ES1-455: Prevent NPM traffic on healthcheck

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -142,9 +142,12 @@ services:
       - "CMD"
       - "npm"
       - "run"
+      - "--no-update-notifier"
       - "healthcheck:notification-engine"
       - "readiness"
       - "10"
+      - "--"
+      - "--no-update-notifier"
       interval: 5s
       timeout: 5s
       retries: 3
@@ -178,6 +181,8 @@ services:
       - "run"
       - "healthcheck:notification-sender"
       - "readiness"
+      - "--"
+      - "--no-update-notifier"
     entrypoint: npm run
     command: "start:notification-sender"
 
@@ -211,6 +216,8 @@ services:
       - "run"
       - "healthcheck:datalake-maintainer"
       - "liveness"
+      - "--"
+      - "--no-update-notifier"
     entrypoint: npm run
     command: "start:datalake-maintainer"
     volumes:

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -142,7 +142,6 @@ services:
       - "CMD"
       - "npm"
       - "run"
-      - "--no-update-notifier"
       - "healthcheck:notification-engine"
       - "readiness"
       - "10"


### PR DESCRIPTION
# Summary
Our containers make a call to NPM each time the health check runs. Adding this flag to the `npm run` command will prevent the network call to check versions from happening.

# Caveat
This is really hard to test in GitPod, please confirm everything runs smoothly in Edge using the `plextrac-manager-util` before merging this. I've done my best to test usage using alternative methods, but nothing beats testing the actual change.

<img width="654" alt="Screenshot 2023-08-21 at 11 32 34 AM" src="https://github.com/PlexTrac/plextrac-manager-util/assets/136384543/8829c7b6-0d5d-452a-90da-2946d3932660">

# Jira
https://plextrac.atlassian.net/browse/ES1-445