### PR TITLE
Update: Rolling Update Functionality

### DIFF
--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -12,16 +12,58 @@ function compose_client() {
   docker-compose $(echo $compose_files) ${flags[@]}
 }
 
+function image_version_check() {
+  if [ $IMAGE_PRECHECK == true ]
+    then
+      IMAGE_CHANGED=true
+      IMAGE_PRECHECK=false
+      expected_services=""
+      current_services=""
+      current_image_digests=""
+      # Get list of expected services from the `docker compose config`
+      expected_services=$(docker compose config --format json | jq -re .services[].image | sort -u)
+      debug "Expected Services `echo "$expected_services" | wc -l`"
+      debug "$expected_services"
+      current_services=$(for i in `compose_client images -q`; do docker image inspect "$i" --format json | jq -re '(.[].RepoTags[])'; done | sort)
+      current_image_digests=$(for i in `grep -F -x -f <(echo "$expected_services") <(echo "$current_services")`; do docker image inspect $i --format json | jq -re '.[].RepoDigests[]'; done | sort)
+      debug "Current Images Matching `echo "$current_image_digests" | wc -l`"
+      debug "$current_image_digests"
+      if [ "$(echo "$current_image_digests" | wc -l)" -ne "$(echo "$expected_services" | wc -l)" ]
+        then
+          debug "Number of desired service images does NOT match!"
+          debug "The Image or number of running images has changed. Scaling"
+          IMAGE_CHANGED=true
+        else 
+          IMAGE_CHANGED=false
+      fi
+    else
+      if [ $IMAGE_CHANGED == false ]
+        then
+          local new_services=$(for i in `compose_client images -q`; do docker image inspect $i --format json | jq -re '(.[].RepoTags[])'; done | sort -u)
+          local new_image_digests=$(for i in `grep -F -x -f <(echo "$expected_services") <(echo "$new_services")`; do docker image inspect $i --format json | jq -re '.[].RepoDigests[]'; done | sort)
+          debug "New Images Matching `echo "$new_image_digests" | wc -l`"
+          debug "$new_image_digests"
+          if [ "$new_image_digests" = "$current_image_digests" ]
+            then 
+              IMAGE_CHANGED=false
+            else
+              IMAGE_CHANGED=true
+          fi
+      fi
+  fi
+}
+
 function pull_docker_images() {
   info "Pulling updated docker images"
-  #precheck
+  IMAGE_PRECHECK=true
+  image_version_check
   if tty -s; then
     ARGS=''
   else
     ARGS='-q'
   fi
   compose_client pull ${ARGS:-}
-  #postcheck
+  image_version_check
   info "Done."
 }
 

--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -14,12 +14,14 @@ function compose_client() {
 
 function pull_docker_images() {
   info "Pulling updated docker images"
+  #precheck
   if tty -s; then
     ARGS=''
   else
     ARGS='-q'
   fi
   compose_client pull ${ARGS:-}
+  #postcheck
   info "Done."
 }
 

--- a/src/_rollout.sh
+++ b/src/_rollout.sh
@@ -1,0 +1,113 @@
+# Credits
+# "SchemaVersion": "0.1.0",
+# "Vendor": "Karol Musur",
+# "Version": "v0.5",
+# "ShortDescription": "Rollout new Compose service version"
+# "Adapted by": "Michael Burke"
+
+# Defaults
+HEALTHCHECK_TIMEOUT=60
+NO_HEALTHCHECK_TIMEOUT=10
+
+healthcheck() {
+  local container_id="$1"
+
+  if docker inspect --format='{{json .State.Health.Status}}' "$container_id" | grep -v "unhealthy" | grep -q "healthy"; then
+    return 0
+  fi
+
+  return 1
+}
+
+scale() {
+  local service="$1"
+  local replicas="$2"
+  compose_client up --detach --scale $service=$replicas --no-recreate "$service"
+}
+
+mod_rollout() {
+  # Added removal of the couchbase-migrations container due to this not getting attached to the new network scaled
+  if docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations
+    then
+      docker rm -f `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase` > /dev/null 2>&1
+  fi
+  # Get list of services from Docker Compose Config
+  service_list=(
+    "notification-engine"
+    "notification-sender"
+    "plextracapi"
+  )
+  for s in ${service_list[@]}
+    do
+      SERVICE=$s
+      if [[ "$(compose_client ps --quiet "$SERVICE")" == "" ]]; then
+        info "==> Service '$SERVICE' is not running. Starting the service."
+        compose_client up --detach --no-recreate "$SERVICE"
+        info "$SERVICE created"
+        continue
+      fi
+
+      OLD_CONTAINER_IDS_STRING=$(compose_client ps --quiet "$SERVICE")
+      readarray -t OLD_CONTAINER_IDS <<<"$OLD_CONTAINER_IDS_STRING"
+
+      #SCALE=${#OLD_CONTAINER_IDS[@]}
+      SCALE=$(docker compose config --format json | jq -re --arg v "$SERVICE" '.services | .[$v].deploy.replicas | select(. != null)')
+      SCALE_TIMES_TWO=$((SCALE * 2))
+      info "==> Scaling '$SERVICE' to '$SCALE_TIMES_TWO'"
+      scale "$SERVICE" $SCALE_TIMES_TWO
+
+      # create a variable that contains the IDs of the new containers, but not the old ones
+      NEW_CONTAINER_IDS_STRING=$(compose_client ps --quiet "$SERVICE" | grep --invert-match --file <(echo "$OLD_CONTAINER_IDS_STRING"))
+      readarray -t NEW_CONTAINER_IDS <<<"$NEW_CONTAINER_IDS_STRING"
+
+      # check if first container has healthcheck
+      if docker inspect --format='{{json .State.Health}}' "${OLD_CONTAINER_IDS[0]}" | grep --quiet "Status"; then
+        info "==> Waiting for new containers to be healthy (timeout: $HEALTHCHECK_TIMEOUT seconds)"
+        for _ in $(seq 1 "$HEALTHCHECK_TIMEOUT"); do
+          SUCCESS=0
+
+          for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
+            if healthcheck "$NEW_CONTAINER_ID"; then
+              SUCCESS=$((SUCCESS + 1))
+            fi
+          done
+
+          if [[ "$SUCCESS" == "$SCALE" ]]; then
+            break
+          fi
+
+          sleep 1
+        done
+
+        SUCCESS=0
+
+        for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
+          if healthcheck "$NEW_CONTAINER_ID"; then
+            SUCCESS=$((SUCCESS + 1))
+          fi
+        done
+
+        if [[ "$SUCCESS" != "$SCALE" ]]; then
+          info "==> New containers are not healthy. Rolling back."
+
+          for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
+            docker stop "$NEW_CONTAINER_ID" > /dev/null 2>&1
+            docker rm "$NEW_CONTAINER_ID" > /dev/null 2>&1
+          done
+
+          exit 1
+        fi
+      else
+        info "==> Waiting for new containers to be ready ($NO_HEALTHCHECK_TIMEOUT seconds)"
+        sleep "$NO_HEALTHCHECK_TIMEOUT"
+      fi
+
+      info "==> Stopping and removing old containers"
+
+      for OLD_CONTAINER_ID in "${OLD_CONTAINER_IDS[@]}"; do
+        docker stop "$OLD_CONTAINER_ID" > /dev/null 2>&1
+        docker rm "$OLD_CONTAINER_ID" > /dev/null 2>&1
+      done
+    done
+    info "Done!"
+}

--- a/src/_rollout.sh
+++ b/src/_rollout.sh
@@ -27,33 +27,51 @@ scale() {
 
 mod_rollout() {
   # Added removal of the couchbase-migrations container due to this not getting attached to the new network scaled
-  if docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations
+  if [ $(docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations) != "" ]
     then
-      docker rm -f `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase` > /dev/null 2>&1
+      debug "Removing 'couchbase-migrations' container"
+      docker rm -f `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations` > /dev/null 2>&1
   fi
   # Get list of services from Docker Compose Config
   service_list=(
+    "datalake-maintainer"
     "notification-engine"
     "notification-sender"
     "plextracapi"
   )
+  #service_list=$(for i in `docker compose config --format json | jq -re '.services|keys[]'`; do \
+  #  docker compose config --format json | jq -re --arg v "$i" '.services | "\($v)=\(.[$v].image)"'; \
+  #  done | grep plextracapi | sort -u | cut -d '=' -f1)
+  debug "$service_list"
   for s in ${service_list[@]}
+  #for s in `echo -ne "$service_list"`
     do
       SERVICE=$s
-      if [[ "$(compose_client ps --quiet "$SERVICE")" == "" ]]; then
-        info "==> Service '$SERVICE' is not running. Starting the service."
-        compose_client up --detach --no-recreate "$SERVICE"
-        info "$SERVICE created"
-        continue
+      SCALE=$(docker compose config --format json | jq -re --arg v "$SERVICE" '.services | .[$v].deploy.replicas | select(. != null)')
+      if [ $SCALE == 0 ]
+        then
+          debug "$SERVICE show $SCALE replicas; skipping"
+          continue
+      fi
+      if [[ "$(compose_client ps --quiet "$SERVICE")" == "" ]]
+        then
+          debug "Service '$SERVICE' is not running. Starting the service."
+          compose_client up --detach --no-recreate "$SERVICE"
+          debug "$SERVICE created"
+          continue
       fi
 
       OLD_CONTAINER_IDS_STRING=$(compose_client ps --quiet "$SERVICE")
       readarray -t OLD_CONTAINER_IDS <<<"$OLD_CONTAINER_IDS_STRING"
 
-      #SCALE=${#OLD_CONTAINER_IDS[@]}
-      SCALE=$(docker compose config --format json | jq -re --arg v "$SERVICE" '.services | .[$v].deploy.replicas | select(. != null)')
-      SCALE_TIMES_TWO=$((SCALE * 2))
-      info "==> Scaling '$SERVICE' to '$SCALE_TIMES_TWO'"
+      if [ $SCALE != "0" ]
+        then
+          SCALE_TIMES_TWO=$((SCALE * 2))
+        else
+          SCALE_TIMES_TWO=0
+          break
+      fi
+      debug "Scaling '$SERVICE' to '$SCALE_TIMES_TWO'"
       scale "$SERVICE" $SCALE_TIMES_TWO
 
       # create a variable that contains the IDs of the new containers, but not the old ones
@@ -61,9 +79,25 @@ mod_rollout() {
       readarray -t NEW_CONTAINER_IDS <<<"$NEW_CONTAINER_IDS_STRING"
 
       # check if first container has healthcheck
-      if docker inspect --format='{{json .State.Health}}' "${OLD_CONTAINER_IDS[0]}" | grep --quiet "Status"; then
-        info "==> Waiting for new containers to be healthy (timeout: $HEALTHCHECK_TIMEOUT seconds)"
-        for _ in $(seq 1 "$HEALTHCHECK_TIMEOUT"); do
+      if docker inspect --format='{{json .State.Health}}' "${OLD_CONTAINER_IDS[0]}" | grep --quiet "Status"
+        then
+          debug "Waiting for new containers to be healthy (timeout: $HEALTHCHECK_TIMEOUT seconds)"
+          for _ in $(seq 1 "$HEALTHCHECK_TIMEOUT"); do
+            SUCCESS=0
+
+            for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
+              if healthcheck "$NEW_CONTAINER_ID"; then
+                SUCCESS=$((SUCCESS + 1))
+              fi
+            done
+
+            if [[ "$SUCCESS" == "$SCALE" ]]; then
+              break
+            fi
+
+            sleep 1
+          done
+
           SUCCESS=0
 
           for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
@@ -72,38 +106,20 @@ mod_rollout() {
             fi
           done
 
-          if [[ "$SUCCESS" == "$SCALE" ]]; then
-            break
+          if [[ "$SUCCESS" != "$SCALE" ]]; then
+            error "New containers are not healthy. Rolling back."
+
+            for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
+              docker stop "$NEW_CONTAINER_ID" > /dev/null 2>&1
+              docker rm "$NEW_CONTAINER_ID" > /dev/null 2>&1
+            done
+
+            exit 1
           fi
-
-          sleep 1
-        done
-
-        SUCCESS=0
-
-        for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
-          if healthcheck "$NEW_CONTAINER_ID"; then
-            SUCCESS=$((SUCCESS + 1))
-          fi
-        done
-
-        if [[ "$SUCCESS" != "$SCALE" ]]; then
-          info "==> New containers are not healthy. Rolling back."
-
-          for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
-            docker stop "$NEW_CONTAINER_ID" > /dev/null 2>&1
-            docker rm "$NEW_CONTAINER_ID" > /dev/null 2>&1
-          done
-
-          exit 1
-        fi
-      else
-        info "==> Waiting for new containers to be ready ($NO_HEALTHCHECK_TIMEOUT seconds)"
-        sleep "$NO_HEALTHCHECK_TIMEOUT"
+        else
+          debug "Waiting for new containers to be ready ($NO_HEALTHCHECK_TIMEOUT seconds)"
+          sleep "$NO_HEALTHCHECK_TIMEOUT"
       fi
-
-      info "==> Stopping and removing old containers"
-
       for OLD_CONTAINER_ID in "${OLD_CONTAINER_IDS[@]}"; do
         docker stop "$OLD_CONTAINER_ID" > /dev/null 2>&1
         docker rm "$OLD_CONTAINER_ID" > /dev/null 2>&1

--- a/src/_rollout.sh
+++ b/src/_rollout.sh
@@ -27,7 +27,7 @@ scale() {
 
 mod_rollout() {
   # Added removal of the couchbase-migrations container due to this not getting attached to the new network scaled
-  if [ $(docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations) != "" ]
+  if [ `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations)` ]
     then
       debug "Removing 'couchbase-migrations' container"
       docker rm -f `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations` > /dev/null 2>&1

--- a/src/_rollout.sh
+++ b/src/_rollout.sh
@@ -27,10 +27,10 @@ scale() {
 
 mod_rollout() {
   # Added removal of the couchbase-migrations container due to this not getting attached to the new network scaled
-  if [ `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations` ]
+  if [ `docker compose ps -a --format json | jq -re '.Name' | grep couchbase-migrations` ]
     then
       debug "Removing 'couchbase-migrations' container"
-      docker rm -f `docker compose ps -a --format json | jq -re '.[].Name' | grep couchbase-migrations` > /dev/null 2>&1
+      docker rm -f `docker compose ps -a --format json | jq -re '.Name' | grep couchbase-migrations` > /dev/null 2>&1
   fi
   # Get list of services from Docker Compose Config
   service_list=(

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -18,9 +18,13 @@ function mod_update() {
   else
     info "Skipping self upgrade"
   fi
+
   info "Updating PlexTrac instance to latest release..."
   mod_configure
+  #precheck: get image information
   pull_docker_images
+  #postcheck get image information
+  mod_rollout
 
   # Sometimes containers won't start correctly at first, but will upon a retry
   maxRetries=2

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -21,10 +21,13 @@ function mod_update() {
 
   info "Updating PlexTrac instance to latest release..."
   mod_configure
-  #precheck: get image information
+  title "Pulling latest container images"
   pull_docker_images
-  #postcheck get image information
-  mod_rollout
+  if [ "$IMAGE_CHANGED" == true ]
+    then
+      title "Executing Rolling Deployment"
+      mod_rollout
+  fi
 
   # Sometimes containers won't start correctly at first, but will upon a retry
   maxRetries=2


### PR DESCRIPTION
### Provide **Rolling Deploy** functionality to decrease down time on `plextrac update`
- Added rollout functionality to scale services before destroying the containers
- Added pre/post checks on image validation prior to scaling process
- Ensured rollback feature was functional with current error handling
  - Services will keep running containers `running` and stop the update if health-checks are failing

This gets us _close_ to zero-down time. Now we just need to figure out maintenance mode, and the port-bound services needing to be recreated (`plextracnginx` mainly). The solution below will still involve down time, but less of it.

#### Problem: `plextrac update` current involves downtime for most service components of PlexTrac
<details>

![image](https://github.com/PlexTrac/plextrac-manager-util/assets/72173919/bc708338-5485-4fc4-b310-0ac89a8d6b04)
</details>


#### Solution
I used a code sample from [Karol Musur](https://github.com/Wowu/docker-rollout) who wrote a MIT Licensed bash implementation of rolling updates in an effort to achieve zero-downtime with docker compose so full credit to them for the initial implementation. I then took it and tore it apart to fit with our method of using `docker compose up -d`.

This involves a new `src/_rollout.sh` file that hooks into the `mod_update` function under `src/_update`. I also did digest validation to that if there hasn't been an image or image version change, then to simply start PlexTrac (`plextrac start`).

#### Testing

- [x] `plextrac update` now dynamically gets the list of services that are scalable from the `docker-compose.*` files
    <details>

    ![image](https://github.com/PlexTrac/plextrac-manager-util/assets/72173919/31a5d892-6dc2-457b-81b0-112cb761f68c)
    </details>
    
- [x] `plextrac update` will now scale services up with the new image BEFORE destroying the old images
    <details>

    ![image](https://github.com/PlexTrac/plextrac-manager-util/assets/72173919/d41be4ce-ccf0-44a8-a2d9-4fc1bcec17d1)
    </details>

- [x] `plextrac update` rollout function will now roll back to prior running containers if the health-checks are failing

#### Documentation update
- [ ] None as this hooks into existing functionality
