### PR TITLE
Update: Contiguous Updates

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,12 +25,12 @@ supportedBoxes = [
   {
     :name     => "ubuntu",
     :box      => "bento/ubuntu-20.04",
-    :default  => true,
+    :default  => false,
   },
   {
     :name     => "ubuntu2204",
     :box      => "bento/ubuntu-22.04",
-    :default  => false,
+    :default  => true,
   },
 ]
 

--- a/src/_check.sh
+++ b/src/_check.sh
@@ -40,21 +40,20 @@ function check_for_maintenance_mode() {
 function mod_etl_fix() {
   debug "Running ETL Fix"
   local dir=`compose_client exec plextracapi find -type d -name etl-logs`
-  if [ -n "$dir" ]
-  then
+  if [ -n "$dir" ]; then
     local owner=`compose_client exec plextracapi stat -c '%U' uploads/etl-logs`
     info "Checking volume permissions"
     if [ "$owner" != "plextrac" ]
       then
         info "Volume permissions are wrong; initiating fix"
-        compose_client exec -u 0 plextracapi chown -R plextrac:plextrac uploads/etl-logs
+        compose_client exec -u 0 plextracapi chown -R 1337:1337 uploads/etl-logs
     else
       info "Volume permissions are correct"
     fi
   else
     info "Fixing ETL Folder creation"
     compose_client exec plextracapi mkdir uploads/etl-logs
-    compose_client exec plextracapi chown -R plextrac:plextrac uploads/etl-logs
+    compose_client exec plextracapi chown -R 1337:1337 uploads/etl-logs
   fi
 }
 

--- a/src/_cli_common_utilities.sh
+++ b/src/_cli_common_utilities.sh
@@ -4,8 +4,9 @@ function get_user_approval() {
   # If non-interactive, log failure and return 1
   # If -y/--assume-yes/ASSUME_YES flags/envvars are set, return 0
   # If -y/--assume-yes/ASSUME_YES flags/envvars are NOT allowed, skip returning 0
+  # If a parameter is passed when the fucntion is called, its assumed this will ignore -y --yes flags
   if [[ -n ${1:-} ]]; then
-      debug "hard-check requested; disallowing return 0 from -y or --assume-yes"
+      debug "hardstop requested; disallowing return 0 from -y or --assume-yes"
     else
       if [ ${ASSUME_YES:-false} == "true" ]; then return 0; fi
   fi

--- a/src/_cli_common_utilities.sh
+++ b/src/_cli_common_utilities.sh
@@ -4,12 +4,7 @@ function get_user_approval() {
   # If non-interactive, log failure and return 1
   # If -y/--assume-yes/ASSUME_YES flags/envvars are set, return 0
   # If -y/--assume-yes/ASSUME_YES flags/envvars are NOT allowed, skip returning 0
-  # If a parameter is passed when the fucntion is called, its assumed this will ignore -y --yes flags
-  if [[ -n ${1:-} ]]; then
-      debug "hardstop requested; disallowing return 0 from -y or --assume-yes"
-    else
-      if [ ${ASSUME_YES:-false} == "true" ]; then return 0; fi
-  fi
+  if [ ${ASSUME_YES:-false} == "true" ]; then return 0; fi
   tty -s || die "Unable to request user approval in non-interactive shell, try passing the -y or --assume-yes CLI flag"
   PS3='Please select an option: '
   select opt in "Yes" "No" "Exit"; do

--- a/src/_cli_common_utilities.sh
+++ b/src/_cli_common_utilities.sh
@@ -3,7 +3,12 @@ function get_user_approval() {
   # If interactive, prompt for user approval & return 0
   # If non-interactive, log failure and return 1
   # If -y/--assume-yes/ASSUME_YES flags/envvars are set, return 0
-  if [ ${ASSUME_YES:-false} == "true" ]; then return 0; fi
+  # If -y/--assume-yes/ASSUME_YES flags/envvars are NOT allowed, skip returning 0
+  if [[ -n ${1:-} ]]; then
+      debug "hard-check requested; disallowing return 0 from -y or --assume-yes"
+    else
+      if [ ${ASSUME_YES:-false} == "true" ]; then return 0; fi
+  fi
   tty -s || die "Unable to request user approval in non-interactive shell, try passing the -y or --assume-yes CLI flag"
   PS3='Please select an option: '
   select opt in "Yes" "No" "Exit"; do

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -111,6 +111,12 @@ function login_dockerhub() {
   output="`docker login -u ${DOCKER_HUB_USER:-plextracusers} --password-stdin 2>&1 <<< "${DOCKER_HUB_KEY}"`" || die "${output}"
   debug "$output"
   log "Done."
+
+  if [ -n ${IMAGE_REGISTRY:-} ]; then
+    output="`docker login ${IMAGE_REGISTRY} -u ${IMAGE_REGISTRY_USER:-plextracusers} --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}"`" || die "${output}"
+    debug "$output"
+    log "Done."
+  fi
 }
 
 function updateComposeConfig() {

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -112,7 +112,7 @@ function login_dockerhub() {
   debug "$output"
   log "Done."
 
-  if [ -n ${IMAGE_REGISTRY:-} ]; then
+  if [ -n "${IMAGE_REGISTRY:-}" ]; then
     output="`docker login ${IMAGE_REGISTRY} -u ${IMAGE_REGISTRY_USER:-plextracusers} --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}"`" || die "${output}"
     debug "$output"
     log "Done."

--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -66,7 +66,7 @@ function pull_docker_images() {
   fi
   compose_client pull ${ARGS:-}
   image_version_check
-  info "Done."
+  log "Done."
 }
 
 function composeConfigNeedsUpdated() {
@@ -88,5 +88,5 @@ function docker_createInitialComposeOverrideFile() {
     info "Creating initial $targetOverrideFile"
     echo "$DOCKER_COMPOSE_OVERRIDE_ENCODED" | base64 -d > "$targetOverrideFile"
   fi
-  log "Done"
+  log "Done."
 }

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -13,6 +13,8 @@ function mod_info() {
   echo >&2 ""
   info "Services:"
   msg "    %s\n" "`releaseDetails`"
+  echo >&2 ""
+  info "Upgrade Strategy: ${UPGRADE_STRATEGY:-stable}"
 
   title "Docker Compose"
 

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -89,6 +89,7 @@ EOINITDBSCRIPT
   # without adding failure points is just allow other users to read the (not secret)
   # bootstrapping scripts
   debug "`chmod -Rc a+r $targetDir`"
+  log "Done."
 }
 
 function postgres_metrics_validation() {

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -2,84 +2,6 @@
 #
 # Usage: plextrac update
 
-# Need this as a global variable
-
-upgrade_path=()
-function mod_ver_check() {
-  debug "------"
-  debug "-- Beginning version comparison"
-  # Get running version of Backend
-  running_backend_version="$(for i in `docker compose ps plextracapi -q`; do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
-  # Set the needed JWT Token to interact with the DockerHUB API
-  JWT_TOKEN=$(wget --header="Content-Type: application/json" --post-data='{"username": "'$DOCKER_HUB_USER'", "password": "'$DOCKER_HUB_KEY'"}' -O - https://hub.docker.com/v2/users/login/ -q | jq -r .token)
-  if [ -z $JWT_TOKEN ]
-    then
-      error "Unable to retrieve JWT Token for wget, variable empty"
-    else
-      # Validate that the app is running and returning a version
-      if [[ $running_backend_version != "" ]]
-        then
-          # Get the major and minor version from the running containers
-          maj_ver=$(echo "$running_backend_version" | cut -d '.' -f1)
-          min_ver=$(echo "$running_backend_version" | cut -d '.' -f2)
-          # Statically set the version we're expecting breaking changes to begin
-          breaking_ver="1.62"
-          # Set the running version format as x.x
-          running_ver="$maj_ver.$min_ver"
-          # Default values for variables
-          page=1
-          upstream_tags=()
-          latest_ver=""
-          debug "Looking for version $running_ver"
-          while [ $page -lt 600 ]
-            do
-              # Get the available versions from DockerHub and save to array
-              upstream_tags+=(`wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/?page=$page&page_size=1000" -q | jq -r .results[].name | grep -E '(^[0-9]\.[0-9]*$)' || true`)
-              if [ -z $latest_ver ]; then if [[ "${upstream_tags[@]}" != "" ]]; then latest_ver="${upstream_tags[0]}"; else debug "unable to fetch upstream tags"; break; fi; fi
-              if (( $(echo "$latest_ver <= $breaking_ver" | bc -l) )); then debug $breaking_ver not publically available; break; fi
-              if [[ $(echo "${upstream_tags[@]}" | grep "$breaking_ver" || true) ]]
-                then 
-                  debug "Found breaking version $breaking_ver"; break; 
-              elif [[ $(echo "${upstream_tags[@]}" | grep "$running_ver" || true) ]]
-                then
-                  debug "Found running version $running_backend_version"; break; 
-              fi
-              debug "Page of results: $page"
-              page=$[$page+1]
-          done
-          debug "-----"
-          debug "-- Listing version information"
-          debug "Upstream Versions: [${upstream_tags[@]} ]"
-          # This grabs the first element in the version sorted list which should always be the highest version available on DockerHub"
-          latest_ver="${upstream_tags[0]}"
-          debug "Breaking Version: $breaking_ver"
-          debug "Running Version: $running_ver"
-          debug "Latest Version: $latest_ver"
-          debug "Upgrade Strategy: $UPGRADE_STRATEGY"
-
-          # Check if 1.62 is avaiable to the public yet
-          if (( $(echo "$latest_ver >= $breaking_ver" | bc -l) ))
-            then
-              debug "$breaking_ver and above now available to public"
-              debug "Proceeding with contiguous update"
-              # Determine an upgrade path to follow
-              IFS=$'\n' upgrade_path=($(sort -V <<<"${upstream_tags[*]}"))
-              unset IFS
-              debug "Upgrade path: [${upgrade_path[@]}]"
-              # Variable to indicate how to handle updating
-              contiguous_update=true
-          else
-              # if breaking version isn't available, do nothing and update like normal
-              debug "Breaking version $breaking_ver not publically avaialble yet"
-              contiguous_update=false
-          fi
-        else
-          # BACKEND not running or returning version
-          debug "plextracapi not running or returning version"
-      fi
-  fi
-}
-
 # subcommand function, this is the entrypoint eg `plextrac update`
 function mod_update() {
   title "Updating PlexTrac"
@@ -95,31 +17,53 @@ function mod_update() {
     fi
   else
     info "Skipping self upgrade"
-    error "PlexTrac began/will begin doing contiguous updates to the PlexTrac application starting with the v1.62 releas. From that point forward, all releases will need to be updated with minor version increments. Skipping updating the PlexTrac Manager Util can have adverse affects on the application if a minor version update is skipped. Are you sure you want to continue skipping updates to this utility?"
+    error "PlexTrac began/will begin doing contiguous updates to the PlexTrac application starting with the v1.62 release. From that point forward, all releases will need to be updated with minor version increments. Skipping updating the PlexTrac Manager Util can have adverse affects on the application if a minor version update is skipped. Are you sure you want to continue skipping updates to this utility?"
     get_user_approval
   fi
   info "Updating PlexTrac instance to latest release..."
-  # -------- START OF NEW
-  mod_ver_check
-  debug "Contiguous update: $contiguous_update"
-  contiguous_update=true
-  debug "Number of upgrades: $(echo "${#upgrade_path[@]} - 1" | bc -l || 1)"
-  # If $contiguous_update is true
+  # Check upstream tags avaialble to download
+  version_check
   if $contiguous_update
     then
-      if [ $UPGRADE_STRATEGY == "stable" ]; then info "stable is the chosen"; fi
-      info "Running Ver is $running_ver"
       debug "Proceeding with contiguous update"
+      upgrade_time_estimate
       for i in ${upgrade_path[@]}
          do
             if [ "$i" != "$running_ver" ]
               then
-                info "Upgrading to $i"
+                debug "Upgrading to $i"
+                mod_configure
                 UPGRADE_STRATEGY="$i"
-                info "UPGRADE_STRATEGY is now $UPGRADE_STRATEGY"
+                debug "Upgrade Strategy is $UPGRADE_STRATEGY"
+                title "Pulling latest container images"
+                exit
+                pull_docker_images
+                if [ "$IMAGE_CHANGED" == true ]
+                  then
+                    title "Executing Rolling Deployment"
+                    mod_rollout
+                fi
+                # Sometimes containers won't start correctly at first, but will upon a retry
+                maxRetries=2
+                for i in $( seq 1 $maxRetries ); do
+                  mod_start || sleep 5 # Wait before going on to health checks, they should handle triggering retries if mod_start errors
+                  unhealthy_services=$(compose_client ps -a --format json | \
+                    jq -r '. | select(.Health == "unhealthy" or (.State != "running" and .ExitCode != 0) or .State == "created" ) | .Service' | \
+                    xargs -r printf "%s;")
+                  if [[ "${unhealthy_services}" == "" ]]; then break; fi
+                  info "Detected unhealthy services: ${unhealthy_services}"
+                  if [[ $i -ge $maxRetries ]]; then
+                    error "One or more containers are in a failed state, please contact support!"
+                    exit 1
+                  fi
+                  info "An error occurred with one or more containers, attempting to start again"
+                  sleep 5
+                done
             fi
       done
-    else
+      mod_check
+      title "Update complete"
+  else
       debug "Proceeding with normal update"
       mod_configure
       title "Pulling latest container images"

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -36,7 +36,6 @@ function mod_update() {
                 UPGRADE_STRATEGY="$i"
                 debug "Upgrade Strategy is $UPGRADE_STRATEGY"
                 title "Pulling latest container images"
-                exit
                 pull_docker_images
                 if [ "$IMAGE_CHANGED" == true ]
                   then
@@ -93,7 +92,6 @@ function mod_update() {
       mod_check
       title "Update complete"
   fi
-  # -------- END OF NEW
 }
 
 function _selfupdate_refreshReleaseInfo() {

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -17,7 +17,7 @@ function mod_update() {
     fi
   else
     info "Skipping self upgrade"
-    error "PlexTrac began/will begin doing contiguous updates to the PlexTrac application starting with the v1.62 release. From that point forward, all releases will need to be updated with minor version increments. Skipping updating the PlexTrac Manager Util can have adverse affects on the application if a minor version update is skipped. Are you sure you want to continue skipping updates to this utility?"
+    error "PlexTrac began/will begin doing contiguous updates to the PlexTrac application starting with the v2.0 release. From that point forward, all releases will need to be updated with minor version increments. Skipping updating the PlexTrac Manager Util can have adverse affects on the application if a minor version update is skipped. Are you sure you want to continue skipping updates to this utility?"
     get_user_approval
   fi
   info "Updating PlexTrac instance to latest release..."

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -1,48 +1,82 @@
 # Instance & Utility Update Management
 #
 # Usage: plextrac update
-ver_between() {
-    # args: min, actual, max
-    printf '%s\n' "$@" | sort -V -C
-}
 
+# Need this as a global variable
+
+upgrade_path=()
 function mod_ver_check() {
+  debug "------"
+  debug "-- Beginning version comparison"
   # Get running version of Backend
   running_backend_version="$(for i in `docker compose ps plextracapi -q`; do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
-  # Validate that the app is running and returning a version
-  if [[ $running_backend_version != "" ]]
+  # Set the needed JWT Token to interact with the DockerHUB API
+  JWT_TOKEN=$(wget --header="Content-Type: application/json" --post-data='{"username": "'$DOCKER_HUB_USER'", "password": "'$DOCKER_HUB_KEY'"}' -O - https://hub.docker.com/v2/users/login/ -q | jq -r .token)
+  if [ -z $JWT_TOKEN ]
     then
-      # Get the major and minor version from the running containers
-      maj_ver=$(echo "$running_backend_version" | cut -d '.' -f1)
-      min_ver=$(echo "$running_backend_version" | cut -d '.' -f2)
-      # Get the available versions from DockerHub and save to array
-      upstream_tags=(`skopeo list-tags docker://plextrac/plextracapi | jq -r .Tags[] | grep -E '(^[0-9]\.[0-9]*$)' | sort -V`)
-      # Statically set the version we're expecting breaking changes to begin
-      breaking_ver="1.62"
-      running_ver="$maj_ver.$min_ver"
-      # This grabs the last element in the version sorted list which should always be the highest version available on DockerHub"
-      latest_ver="${upstream_tags[-1]}"
-      debug "Breaking Version: $breaking_ver"
-      debug "Running Version: $running_ver"
-      debug "Latest Version: $latest_ver"
-      debug "Upgrade Strategy: $UPGRADE_STRATEGY"
-
-      # Check if 1.62 is avaiable to the public yet
-      if (( $(echo "$latest_ver >= $breaking_ver" | bc -l) ))
-        then
-          info "1.62 available to public"
-      else
-          # if breaking version isn't available, do nothing and update like normal
-          debug "breaking version $breaking_ver not publically avaialble yet. Proceeding with update normally"
-      fi
-      
-      
-      # Check if the running version
-      if [[ $breaking_ver < $running_ver ]]; then info "YES"; else info "NO"; fi
+      error "Unable to retrieve JWT Token for wget, variable empty"
     else
-      # BACKEND not running or returning version
-      debug "plextracapi not running or returning version"
-      contigous_update=false
+      # Validate that the app is running and returning a version
+      if [[ $running_backend_version != "" ]]
+        then
+          # Get the major and minor version from the running containers
+          maj_ver=$(echo "$running_backend_version" | cut -d '.' -f1)
+          min_ver=$(echo "$running_backend_version" | cut -d '.' -f2)
+          # Statically set the version we're expecting breaking changes to begin
+          breaking_ver="1.62"
+          # Set the running version format as x.x
+          running_ver="$maj_ver.$min_ver"
+          # Default values for variables
+          page=1
+          upstream_tags=()
+          latest_ver=""
+          debug "Looking for version $running_ver"
+          while [ $page -lt 600 ]
+            do
+              # Get the available versions from DockerHub and save to array
+              upstream_tags+=(`wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/?page=$page&page_size=1000" -q | jq -r .results[].name | grep -E '(^[0-9]\.[0-9]*$)' || true`)
+              if [ -z $latest_ver ]; then if [[ "${upstream_tags[@]}" != "" ]]; then latest_ver="${upstream_tags[0]}"; else debug "unable to fetch upstream tags"; break; fi; fi
+              if (( $(echo "$latest_ver <= $breaking_ver" | bc -l) )); then debug $breaking_ver not publically available; break; fi
+              if [[ $(echo "${upstream_tags[@]}" | grep "$breaking_ver" || true) ]]
+                then 
+                  debug "Found breaking version $breaking_ver"; break; 
+              elif [[ $(echo "${upstream_tags[@]}" | grep "$running_ver" || true) ]]
+                then
+                  debug "Found running version $running_backend_version"; break; 
+              fi
+              debug "Page of results: $page"
+              page=$[$page+1]
+          done
+          debug "-----"
+          debug "-- Listing version information"
+          debug "Upstream Versions: [${upstream_tags[@]} ]"
+          # This grabs the first element in the version sorted list which should always be the highest version available on DockerHub"
+          latest_ver="${upstream_tags[0]}"
+          debug "Breaking Version: $breaking_ver"
+          debug "Running Version: $running_ver"
+          debug "Latest Version: $latest_ver"
+          debug "Upgrade Strategy: $UPGRADE_STRATEGY"
+
+          # Check if 1.62 is avaiable to the public yet
+          if (( $(echo "$latest_ver >= $breaking_ver" | bc -l) ))
+            then
+              debug "$breaking_ver and above now available to public"
+              debug "Proceeding with contiguous update"
+              # Determine an upgrade path to follow
+              IFS=$'\n' upgrade_path=($(sort -V <<<"${upstream_tags[*]}"))
+              unset IFS
+              debug "Upgrade path: [${upgrade_path[@]}]"
+              # Variable to indicate how to handle updating
+              contiguous_update=true
+          else
+              # if breaking version isn't available, do nothing and update like normal
+              debug "Breaking version $breaking_ver not publically avaialble yet"
+              contiguous_update=false
+          fi
+        else
+          # BACKEND not running or returning version
+          debug "plextracapi not running or returning version"
+      fi
   fi
 }
 
@@ -61,45 +95,61 @@ function mod_update() {
     fi
   else
     info "Skipping self upgrade"
+    error "PlexTrac began/will begin doing contiguous updates to the PlexTrac application starting with the v1.62 releas. From that point forward, all releases will need to be updated with minor version increments. Skipping updating the PlexTrac Manager Util can have adverse affects on the application if a minor version update is skipped. Are you sure you want to continue skipping updates to this utility?"
+    get_user_approval
   fi
-  # Check what version this customer is on
-
   info "Updating PlexTrac instance to latest release..."
-  mod_configure
-  title "Pulling latest container images"
-  pull_docker_images
-  if [ "$IMAGE_CHANGED" == true ]
+  # -------- START OF NEW
+  mod_ver_check
+  debug "Contiguous update: $contiguous_update"
+  contiguous_update=true
+  debug "Number of upgrades: $(echo "${#upgrade_path[@]} - 1" | bc -l || 1)"
+  # If $contiguous_update is true
+  if $contiguous_update
     then
-      title "Executing Rolling Deployment"
-      mod_rollout
+      if [ $UPGRADE_STRATEGY == "stable" ]; then info "stable is the chosen"; fi
+      info "Running Ver is $running_ver"
+      debug "Proceeding with contiguous update"
+      for i in ${upgrade_path[@]}
+         do
+            if [ "$i" != "$running_ver" ]
+              then
+                info "Upgrading to $i"
+                UPGRADE_STRATEGY="$i"
+                info "UPGRADE_STRATEGY is now $UPGRADE_STRATEGY"
+            fi
+      done
+    else
+      debug "Proceeding with normal update"
+      mod_configure
+      title "Pulling latest container images"
+      pull_docker_images
+      if [ "$IMAGE_CHANGED" == true ]
+        then
+          title "Executing Rolling Deployment"
+          mod_rollout
+      fi
+
+      # Sometimes containers won't start correctly at first, but will upon a retry
+      maxRetries=2
+      for i in $( seq 1 $maxRetries ); do
+        mod_start || sleep 5 # Wait before going on to health checks, they should handle triggering retries if mod_start errors
+        unhealthy_services=$(compose_client ps -a --format json | \
+          jq -r '. | select(.Health == "unhealthy" or (.State != "running" and .ExitCode != 0) or .State == "created" ) | .Service' | \
+          xargs -r printf "%s;")
+        if [[ "${unhealthy_services}" == "" ]]; then break; fi
+        info "Detected unhealthy services: ${unhealthy_services}"
+        if [[ $i -ge $maxRetries ]]; then
+          error "One or more containers are in a failed state, please contact support!"
+          exit 1
+        fi
+        info "An error occurred with one or more containers, attempting to start again"
+        sleep 5
+      done
+      mod_check
+      title "Update complete"
   fi
-
-  # Sometimes containers won't start correctly at first, but will upon a retry
-  maxRetries=2
-  for i in $( seq 1 $maxRetries ); do
-    mod_start || sleep 5 # Wait before going on to health checks, they should handle triggering retries if mod_start errors
-
-    unhealthy_services=$(compose_client ps -a --format json | \
-      jq -r '. | select(.Health == "unhealthy" or (.State != "running" and .ExitCode != 0) or .State == "created" ) | .Service' | \
-      xargs -r printf "%s;")
-
-    if [[ "${unhealthy_services}" == "" ]]; then break; fi
-
-    info "Detected unhealthy services: ${unhealthy_services}"
-
-    if [[ $i -ge $maxRetries ]]; then
-      error "One or more containers are in a failed state, please contact support!"
-      exit 1
-    fi
-
-    info "An error occurred with one or more containers, attempting to start again"
-    sleep 5
-
-  done
-
-  mod_check
-
-  title "Update complete"
+  # -------- END OF NEW
 }
 
 function _selfupdate_refreshReleaseInfo() {

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -1,3 +1,5 @@
+# TODO: Change plextrac start to NOT pull images
+# Docker compose up pull image?
 # Need this as a global variable
 upgrade_path=()
 
@@ -136,6 +138,8 @@ function version_check() {
           do
             if [[ ${upstream_tags[i]} = $running_ver ]]
               then
+                # TODO remove this function because it won't upgrade if 1.60.10 comes out
+                # Potentially validate if running == latest and pull images anyway?
                 debug "correcting upstream_tags to remove running version"
                 unset 'upstream_tags[i]'
             fi

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -15,7 +15,7 @@ function upgrade_warning() {
   debug "upgrade_warning function running"
   error "Its been detected that you're on a pinned version of PlexTrac other than stable. Beginning with version 2.0, PlexTrac is going to require contiguous updates to ensure code migrations are successful and enable us to continue to move forward with improving the platform. We recommend updating to the next minor version available compared to the running version $running_backend_version"
   error "Are you sure you want to update to $UPGRADE_STRATEGY?"
-  get_user_approval hardstop
+  get_user_approval
 }
 
 function version_check() {
@@ -91,7 +91,7 @@ function version_check() {
         msg "-------"
         error "Beginning with version 2.0, PlexTrac is going to require contiguous updates to ensure code migrations are successful and enable us to continue to move forward with improving the platform. We recommend updating to the next minor version available compared to the running version $running_backend_version"
         error "Are you sure you want to update to $UPGRADE_STRATEGY? (y/n)"
-        get_user_approval hardcheck
+        get_user_approval
     fi
 
     upstream_tags=()

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -65,7 +65,6 @@ function version_check() {
     # Set the needed JWT Token to interact with the DockerHUB API
     # TODO: What is JWT is empty or in Airgapped / on-prem env?
     JWT_TOKEN=$(wget --header="Content-Type: application/json" --post-data='{"username": "'$DOCKER_HUB_USER'", "password": "'$DOCKER_HUB_KEY'"}' -O - https://hub.docker.com/v2/users/login/ -q | jq -r .token)
-    JWT_TOKEN=""
     if [[ -n "$JWT_TOKEN" ]]; then
         # Get latest from DockerHUB and assign to array
         while [ $page -lt 600 ]; do

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -54,7 +54,7 @@ function version_check() {
     #######################
     ### -- Latest Stable Version
     #######################
-    debug "Latest_Stable Version"
+
     # Set vars
     breaking_ver="2.0"
     latest_ver=""
@@ -67,20 +67,20 @@ function version_check() {
         while [ $page -lt 600 ]; do
           latest_ver=($(wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/?page=$page&page_size=1000" -q | jq -r .results[].name | grep -E '(^[0-9]\.[0-9]*$)' || true))
           page=$(($page + 1))
-          debug "$latest_ver"
+          debug "Latest_Stable Version: ${latest_ver[0]}"
           if [ -n "$latest_ver" ]; then break; fi
         done
         # Set latest_ver to first index item which should be the "latest"
         latest_ver="${latest_ver[0]}"
-        
+
         ## LOGIC: LATEST_STABLE
         # IF LATEST_STABLE <= 2.0
         if (( $(echo "$latest_ver <= $breaking_ver" | bc -l) ))
           then 
-            debug "$breaking_ver not publically available. Updating normally without warning"
+            debug "Updating normally to $latest_ver without warning"
             contiguous_update=false
           
-          # IF LATEST_STABLE >= 2.0
+          # IF LATEST_STABLE > 2.0
           else
             debug "Stable version is greater than $breaking_ver. Running contiguous update"
             contiguous_update=true

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -15,7 +15,7 @@ function upgrade_warning() {
   debug "upgrade_warning function running"
   error "Its been detected that you're on a pinned version of PlexTrac other than stable. Beginning with version 2.0, PlexTrac is going to require contiguous updates to ensure code migrations are successful and enable us to continue to move forward with improving the platform. We recommend updating to the next minor version available compared to the running version $running_backend_version"
   error "Are you sure you want to update to $UPGRADE_STRATEGY?"
-  get_user_approval hardcheck
+  get_user_approval hardstop
 }
 
 function version_check() {

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -71,12 +71,6 @@ function version_check() {
         done
         # Set latest_ver to first index item which should be the "latest"
         latest_ver="${latest_ver[0]}"
-
-        ### Compare stable and latest
-        # Get date stable was pushed
-        stable_date=$(date -d $(wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/stable" -q | jq -r .tag_last_pushed) +%s)
-        # Get date for the latest version tag was pushed
-        latest_date=$(date -d $(wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/$latest_ver" -q | jq -r .tag_last_pushed) +%s)
         
         ## LOGIC: LATEST_STABLE
         # IF LATEST_STABLE <= 2.0
@@ -85,7 +79,7 @@ function version_check() {
             debug "$breaking_ver not publically available. Updating normally without warning"
             contiguous_update=false
           
-          # IF LATEST_STABLE >= 2.1
+          # IF LATEST_STABLE >= 2.0
           else
             debug "Stable version is greater than $breaking_ver. Running contiguous update"
             contiguous_update=true
@@ -120,21 +114,6 @@ function version_check() {
             fi
             page=$[$page+1]
         done
-        # Compare stable vs latest_tag and if stable is older than the newest tag, then remove the newest tag to ensure we don't update past stable
-        if [ $stable_date -le $latest_date ]; then
-          debug "Stable is older than latest version"
-          # If stable is older, remove latest from upgrade path
-          for i in ${!upstream_tags[@]}
-            do
-              if [[ ${upstream_tags[i]} = $latest_ver ]]
-                then
-                  debug "correcting upstream_tags to remove latest"
-                  unset 'upstream_tags[i]'
-              fi
-          done
-        else
-          debug "Stable is pinned to the latest version $latest_ver"
-        fi
         
         # Remove the running version from the Upgrade path
         for i in ${!upstream_tags[@]}

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -1,0 +1,175 @@
+# Need this as a global variable
+upgrade_path=()
+
+function upgrade_time_estimate() {
+  debug "upgrade_time_estimate function running"
+  if (( ${#upgrade_path[@]} >= 1 ))
+    then
+      time_estimate=$(echo "${#upgrade_path[@]} * 15" | bc -l)
+      error "Detected ${#upgrade_path[@]} upgrade(s). Each upgrade can take up to 15 minutes to pull the new version, and update the running application. Given the number of upgrades, the projected upgade time is $time_estimate. Are you sure you want to continue?"
+      get_user_approval
+  fi
+}
+
+function upgrade_warning() {
+  debug "upgrade_warning function running"
+  error "Its been detected that you're on a pinned version of PlexTrac other than stable. Beginning with version 1.62, PlexTrac is going to require contiguous updates to ensure code migrations are successful and enable us to continue to move forward with improving the platform."
+  error "Are you sure you want to update to $UPGRADE_STRATEGY?"
+  get_user_approval
+}
+
+function version_check() {
+  #######################
+  ### -- Running Version
+  #######################
+  ## LOGIC: RunVer
+  title "Running Version"
+  # Get running version of Backend
+  running_backend_version="$(for i in $(docker compose ps plextracapi -q); do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
+
+  # CONDITION: plextracapi IS/NOT RUNNING
+  # Validate that the app is running and returning a version
+  if [[ $running_backend_version != "" ]]; then
+    debug "RunVer: plextracapi is running and is version $running_backend_version"
+    # Get the major and minor version from the running containers
+    maj_ver=$(echo "$running_backend_version" | cut -d '.' -f1)
+    min_ver=$(echo "$running_backend_version" | cut -d '.' -f2)
+    # Set the running version format as x.x
+    running_ver="$maj_ver.$min_ver"
+  else
+    debug "RunVer: plextracapi is NOT running"
+    die "plextracapi service isn't running. Please run 'plextrac start' and re-run the update"
+  fi
+
+  #######################
+  ### -- Pinned Version
+  #######################
+  ## LOGIC: PinVer
+  title "Pinned Version"
+  # Check what the pinned version (UPGRADE_STRATEGY) is and see if a contiguous update will apply
+  ## IF STABLE
+  if [[ "$UPGRADE_STRATEGY" == "stable" ]]; then
+    debug "PinVer: Running Stable!"
+
+    #######################
+    ### -- Latest Stable Version
+    #######################
+    title "Latest_Stable Version"
+    # Set vars
+    breaking_ver="1.62"
+    latest_ver=""
+    page=1
+
+    # Set the needed JWT Token to interact with the DockerHUB API
+    # TODO: What is JWT is empty or in Airgapped / on-prem env?
+    JWT_TOKEN=$(wget --header="Content-Type: application/json" --post-data='{"username": "'$DOCKER_HUB_USER'", "password": "'$DOCKER_HUB_KEY'"}' -O - https://hub.docker.com/v2/users/login/ -q | jq -r .token)
+
+    # Get latest from DockerHUB and assign to array
+    while [ $page -lt 600 ]; do
+      latest_ver=($(wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/?page=$page&page_size=1000" -q | jq -r .results[].name | grep -E '(^[0-9]\.[0-9]*$)' || true))
+      page=$(($page + 1))
+      if [ -n $latest_ver ]; then break; fi
+    done
+    # Set latest_var to first index item which should be the "latest"
+    latest_ver="${latest_ver[0]}"
+
+    ### Compare stable and latest
+    # Get date stable was pushed
+    stable_date=$(date -d $(wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/stable" -q | jq -r .tag_last_pushed) +%s)
+    # Get date for the latest version tag was pushed
+    latest_date=$(date -d $(wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/$latest_ver" -q | jq -r .tag_last_pushed) +%s)
+    
+    ## LOGIC: LATEST_STABLE
+    # IF LATEST_STABLE <= 1.62
+    if (( $(echo "$latest_ver <= $breaking_ver" | bc -l) ))
+      then 
+        debug "$breaking_ver not publically available. Updating normally without warning"
+        contiguous_update=false
+      
+      # IF LATEST_STABLE >= 1.63
+      else
+        debug "stable version is greater than $breaking_ver. Running contiguous update"
+        contiguous_update=true
+    fi
+
+    # TEST
+    contiguous_update=true
+    upstream_tags=()
+    page=1
+    if [ "$contiguous_update" = true ]
+      then
+        # Get upstream tag list
+        debug "Looking for Running version $running_ver or Breaking version $breaking_ver"
+        while [ $page -lt 600 ]
+          do
+            # Get the available versions from DockerHub and save to array
+            if [[ $(echo "${upstream_tags[@]}" | grep "$breaking_ver" || true) ]]
+              then
+                debug "Found breaking version $breaking_ver"; break;
+            elif [[ $(echo "${upstream_tags[@]}" | grep "$running_ver" || true) ]]
+              then
+                debug "Found running version $running_backend_version"; break;
+            else
+              upstream_tags+=(`wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/?page=$page&page_size=1000" -q | jq -r .results[].name | grep -E '(^[0-9]\.[0-9]*$)' || true`)
+            fi
+            debug "Page of results: $page"
+            page=$[$page+1]
+        done
+        # Compare stable vs latest_tag and if stable is older than the newest tag, then remove the newest tag to ensure we don't update past stable
+        if [ $stable_date -le $latest_date ]; then
+          debug "Stable is older than latest version"
+          # If stable is older, remove latest from upgrade path
+          for i in ${!upstream_tags[@]}
+            do
+              if [[ ${upstream_tags[i]} = $latest_ver ]]
+                then
+                  debug "correcting upstream_tags to remove latest"
+                  unset 'upstream_tags[i]'
+              fi
+          done
+        else
+          debug "Stable is pinned to the latest version $latest_ver"
+        fi
+        
+        # Remove the running version from the Upgrade path
+        for i in ${!upstream_tags[@]}
+          do
+            if [[ ${upstream_tags[i]} = $running_ver ]]
+              then
+                debug "correcting upstream_tags to remove running version"
+                unset 'upstream_tags[i]'
+            fi
+        done
+        for i in "${!upstream_tags[@]}"; do
+            new_array+=( "${upstream_tags[i]}" )
+        done
+        upstream_tags=("${new_array[@]}")
+        unset new_array
+        debug "New upgrade path: ${upstream_tags[@]}"
+        # This grabs the first element in the version sorted list which should always be the highest version available on DockerHub; this should match stable's version"
+        latest_ver="${upstream_tags[0]}"
+        TIFS=$'\n' upgrade_path=($(sort -V <<<"${upstream_tags[*]}"))
+        unset TIFS
+        debug "------------"
+        debug "Listing version information"
+        debug "------------"
+        debug "Upgrade Strategy: $UPGRADE_STRATEGY"
+        debug "Running Version: $running_ver"
+        debug "Breaking Version: $breaking_ver"
+        debug "Upstream Versions: [${upstream_tags[@]}]"
+        debug "Latest Version: $latest_ver"
+        debug "Upgrade path: [${upgrade_path[@]}]"
+        debug "Number of upgrades: ${#upgrade_path[@]}"
+      # TODO: How to handle NON-CONTIGUOUS Update
+      else
+        debug "Else"
+    fi
+  ## IF NOT STABLE
+  else
+    # Running Pinned Version; Normal update with warning
+    debug "PinVer: Running as a non-stable, pinned version -- proceed with warning and update"
+    contiguous_update=false
+    # TODO: warning function
+    upgrade_warning
+  fi
+}

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -34,7 +34,7 @@ function version_check() {
     # Get the major and minor version from the running containers
     maj_ver=$(echo "$running_backend_version" | cut -d '.' -f1)
     min_ver=$(echo "$running_backend_version" | cut -d '.' -f2)
-    # Set the running version format as x.x
+    running_ver=$(echo $running_backend_version | awk -F. '{print $1"."$2}')
     running_ver="$maj_ver.$min_ver"
   else
     debug "RunVer: plextracapi is NOT running"

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -103,6 +103,18 @@ function version_check() {
         while [ $page -lt 600 ]
           do
             # Get the available versions from DockerHub and save to array
+            upstream_tags+=(`wget --header="Authorization: JWT "${JWT_TOKEN} -O - "https://hub.docker.com/v2/repositories/plextrac/plextracapi/tags/?page=$page&page_size=1000" -q | jq -r .results[].name | grep -E '(^[0-9]\.[0-9]*$)' || true`)
+            if [[ ${upstream_tags[@]} =~ "$breaking_ver" ]]
+              then
+                debug "Found breaking version $breaking_ver"; break;
+            elif [[ ${upstream_tags[@] =~ "$running_ver" ]]
+              then
+                debug "Found running version $running_backend_version"; break;
+            page=$[$page+1]
+            fi
+        done
+          do
+            # Get the available versions from DockerHub and save to array
             if [[ $(echo "${upstream_tags[@]}" | grep "$breaking_ver" || true) ]]
               then
                 debug "Found breaking version $breaking_ver"; break;

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.4.3
+VERSION=0.5.0
 
 trap 'cleanup $?' SIGINT ERR EXIT
 


### PR DESCRIPTION
## Goal
- Enable contiguous updates to the PlexTrac application starting with `2.0`
  - E.g., if a customer is running `1.55`, the application will update to `2.0`, and then `2.1`, `2.2`, etc to current version
  - E.g., if a customer is running `2.3`, the application will updates to `2.4`, `2.5`, etc to current version
- Ensure that method doesn't block updates for on-prem and air-gapped customers who's app doesn't contact dockerhub at all

## Tasks To-do
- [x] Notate if SKIP_SELF_UPGRADE is checked and handle upgrade with user input and message acknowledging the need for contiguous updates from `2.0` on
- [x] Error handling if JWT Token is empty
- [x] Scope versions fetched for comparison between newest, to running configuration and handle 
- [x] Add logic to check if `2.0` is available to the public
- [x] Add logic to check if the running version is before `2.0` and if so to update straight to `2.0`, and then contiguously after (`1.55 -> 2.0 -> 2.1 -> 2.2 -> etc`)
- [x] Add time estimate and user input to validate that they want to upgrade and take that time
- [x] Updated `Vagrantfile` to use Ubuntu 22.04
- [x] Added hard check to ensure admin's known how long down time will be
- [x] Bump version to 0.5.0
