### PR TITLE
QS-756: Standardize envs and entrypoints

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -51,8 +51,6 @@ services:
          npm run maintenance:disable"
     env_file:
     - .env
-    environment:
-      PG_MIGRATE_PATH: /usr/src/plextrac-api
 
   plextracdb:
     environment:

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       - 'import requests'
       - 'print(requests.get("http://127.0.0.1:4350/api/v2/health/live").json())'
       - 'EOF'
-
+    entrypoint: npm run
+    command: "start"
 
   couchbase-migrations:
     profiles:
@@ -48,24 +49,10 @@ services:
          npm run db:migrate &&
          npm run pg:etl up all &&
          npm run maintenance:disable"
+    env_file:
+    - .env
     environment:
-      COUCHBASE_URL: ${COUCHBASE_URL:-http://plextracdb}
-      CB_API_PASS: ${CB_API_PASS}
-      CB_API_USER: ${CB_API_USER}
-      REDIS_CONNECTION_STRING: ${REDIS_CONNECTION_STRING:-redis}
-      REDIS_PASSWORD: ${REDIS_PASSWORD:?err}
-      PG_HOST: ${PG_HOST:-postgres}
       PG_MIGRATE_PATH: /usr/src/plextrac-api
-      PG_CORE_ADMIN_PASSWORD: ${PG_CORE_ADMIN_PASSWORD:?err}
-      PG_CORE_ADMIN_USER: ${PG_CORE_ADMIN_USER:?err}
-      PG_CORE_DB: ${PG_CORE_DB:?err}
-      PG_RUNBOOKS_ADMIN_PASSWORD: ${PG_RUNBOOKS_ADMIN_PASSWORD:?err}
-      PG_RUNBOOKS_ADMIN_USER: ${PG_RUNBOOKS_ADMIN_USER:?err}
-      PG_RUNBOOKS_RW_PASSWORD: ${PG_RUNBOOKS_RW_PASSWORD:?err}
-      PG_RUNBOOKS_RW_USER: ${PG_RUNBOOKS_RW_USER:?err}
-      PG_RUNBOOKS_DB: ${PG_RUNBOOKS_DB:?err}
-      PG_TENANTS_WRITE_MODE: ${PG_TENANTS_WRITE_MODE:-couchbase_only}
-      PG_TENANTS_READ_MODE: ${PG_TENANTS_READ_MODE:-couchbase_only}
 
   plextracdb:
     environment:
@@ -129,14 +116,8 @@ services:
     - plextracdb
     - redis
     restart: always
-    environment:
-      CB_API_PASS: "${CB_API_PASS:?err}"
-      CB_API_USER: "${CB_API_USER:?err}"
-      COUCHBASE_URL: "http://plextracdb"
-      LOG_LEVEL: "${LOG_LEVEL:-info}"
-      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
-      API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE: "${API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE:?err}"
+    env_file:
+    - .env
     healthcheck:
       test:
       - "CMD"
@@ -162,17 +143,8 @@ services:
     - plextracdb
     - redis
     restart: always
-    environment:
-      CB_API_PASS: "${CB_API_PASS:?err}"
-      CB_API_USER: "${CB_API_USER:?err}"
-      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
-      COUCHBASE_URL: "http://plextracdb"
-      LOG_LEVEL: ${LOG_LEVEL:-info}
-      MAILER_SECURE: ${MAILER_SECURE:-}
-      NOTIFICATION_DRY_RUN: ${NOTIFICATION_DRY_RUN:-}
-      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
-      serviceConfig: ${serviceConfig:-}
+    env_file:
+    - .env
     healthcheck:
       test:
       - "CMD"
@@ -194,20 +166,10 @@ services:
     - plextracdb
     - redis
     restart: always
+    env_file:
+    - .env
     environment:
-      CB_API_PASS: "${CB_API_PASS:?err}"
-      CB_API_USER: "${CB_API_USER:?err}"
-      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
-      COUCHBASE_URL: "http://plextracdb"
       GCP_DATALAKE_SA_KEY_PATH: "${GCP_DATALAKE_SA_KEY_PATH:-/usr/src/plextrac-api/keys/gcp/gcp-datalake-sa-key.json}"
-      LOG_LEVEL: ${LOG_LEVEL:-info}
-      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
-      PG_CORE_DB: ${PG_CORE_DB:?err}
-      PG_CORE_RO_PASSWORD: ${PG_CORE_RO_PASSWORD:?err}
-      PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
-      PG_CORE_RW_PASSWORD: ${PG_CORE_RW_PASSWORD:?err}
-      PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
     healthcheck:
       test:
       - "CMD"


### PR DESCRIPTION
## Description

The goal of this changeset is to standardize the way environment variables and entrypoints are applied to all the containers which use the backend image. During development these containers share a single .env file and all env vars are present in each process (api, notification-engine, notification-sender, etc,.).  However we do not apply this same pattern in production which can cause confusion and unnecessary complexity when rolling out new services or adding functionality to existing services other than the `plextracapi`.

## Testing Steps

- in an existing docker-compose environment checkout this branch of the manger-util
- Run `plextrac update -v`
- Observe that all services come up and function
- Trigger some action in the UI which will send emails such as resetting your password.
- Verify the email was sent (this will verify both the notification services are working and redis)