### PR TITLE
OPC: Adding Contextual Scoring service definition to default docker compose

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -260,6 +260,36 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     restart: always
+  contextual-scoring-service:
+    image: registry.dorf.plextrac.ninja/cicd-app-images/backend:${BACKEND_IMAGE:-$UPGRADE_STRATEGY}
+    deploy:
+      replicas: 1
+    depends_on:
+    - postgres
+    - redis
+    restart: always
+    environment:
+      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
+      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
+      PG_HOST: ${PG_HOST:?err}
+      PG_CORE_DB: ${PG_CORE_DB:?err}
+      PG_CORE_RW_PASSWORD: ${PG_CORE_RW_PASSWORD:?err}
+      PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
+      PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
+      PG_CORE_RO_PASSWORD: ${PG_CORE_RO_PASSWORD:?err}
+      PG_DEBUG_QUERY_LOGGING: "true"
+    healthcheck:
+      test:
+      - "CMD"
+      - "npm"
+      - "run"
+      - "healthcheck:contextual-scoring-service"
+      - "liveness"
+      - "--"
+      - "--no-update-notifier"
+    entrypoint: npm run
+    command: "start:contextual-scoring-service"
 
 volumes:
   dbdata: {}

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -260,6 +260,7 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     restart: always
+
   contextual-scoring-service:
     image: registry.dorf.plextrac.ninja/cicd-app-images/backend:${BACKEND_IMAGE:-$UPGRADE_STRATEGY}
     deploy:


### PR DESCRIPTION
Adding the Contextual Scoring Service definition to the default docker-compose.yml for easier deployment