### PR TITLE
Removing definition to avoid causing upgrade issue for customer upgrading to version prior to 2.1

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -261,37 +261,6 @@ services:
     - 127.0.0.1:5432:5432/tcp
     restart: always
 
-  contextual-scoring-service:
-    image: registry.dorf.plextrac.ninja/cicd-app-images/backend:${BACKEND_IMAGE:-$UPGRADE_STRATEGY}
-    deploy:
-      replicas: 1
-    depends_on:
-    - postgres
-    - redis
-    restart: always
-    environment:
-      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
-      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
-      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
-      PG_HOST: ${PG_HOST:?err}
-      PG_CORE_DB: ${PG_CORE_DB:?err}
-      PG_CORE_RW_PASSWORD: ${PG_CORE_RW_PASSWORD:?err}
-      PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
-      PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
-      PG_CORE_RO_PASSWORD: ${PG_CORE_RO_PASSWORD:?err}
-      PG_DEBUG_QUERY_LOGGING: "true"
-    healthcheck:
-      test:
-      - "CMD"
-      - "npm"
-      - "run"
-      - "healthcheck:contextual-scoring-service"
-      - "liveness"
-      - "--"
-      - "--no-update-notifier"
-    entrypoint: npm run
-    command: "start:contextual-scoring-service"
-
 volumes:
   dbdata: {}
   uploads: {}


### PR DESCRIPTION
The Contextual Scoring Service was intended to rollout with version 2.1 and a few canary customers. We made the change to the plextrac-manager-util static `docker-compose.yml` file to include the Contextual Scoring Service definition. Unfortunately, because the plextrac-manager-util is not tied to the specific backend repo version, any customer running the util is getting the same `contextual-scoring-service` definition. This has caused upgrades in environments version `2.0` and lower to fail to complete the update