### PR TITLE
Adding the Contextual Scoring Service definition with public image tag

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -260,6 +260,37 @@ services:
     ports:
     - 127.0.0.1:5432:5432/tcp
     restart: always
+  
+  contextual-scoring-service:
+    image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+    deploy:
+      replicas: 1
+    depends_on:
+    - postgres
+    - redis
+    restart: always
+    environment:
+      CLIENT_DOMAIN_NAME: ${CLIENT_DOMAIN_NAME:?err}
+      REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
+      REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
+      PG_HOST: ${PG_HOST:?err}
+      PG_CORE_DB: ${PG_CORE_DB:?err}
+      PG_CORE_RW_PASSWORD: ${PG_CORE_RW_PASSWORD:?err}
+      PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
+      PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
+      PG_CORE_RO_PASSWORD: ${PG_CORE_RO_PASSWORD:?err}
+      PG_DEBUG_QUERY_LOGGING: "true"
+    healthcheck:
+      test:
+      - "CMD"
+      - "npm"
+      - "run"
+      - "healthcheck:contextual-scoring-service"
+      - "liveness"
+      - "--"
+      - "--no-update-notifier"
+    entrypoint: npm run
+    command: "start:contextual-scoring-service"
 
 volumes:
   dbdata: {}

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -265,6 +265,11 @@ services:
     image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
     deploy:
       replicas: 1
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 5
+        window: 120s
     depends_on:
     - postgres
     - redis

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -279,7 +279,7 @@ services:
       PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
       PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
       PG_CORE_RO_PASSWORD: ${PG_CORE_RO_PASSWORD:?err}
-      PG_DEBUG_QUERY_LOGGING: "true"
+      PG_DEBUG_QUERY_LOGGING: "false"
     healthcheck:
       test:
       - "CMD"


### PR DESCRIPTION
After looking at the service definition that was added here https://github.com/PlexTrac/plextrac-manager-util/pull/103 it looks like we were referencing an internal docker registry as opposed to the public one that customers should be using for pulling the public `plextracapi` image. 

We've got 36 canary customers running Contextual Scoring with version `2.1` so ideally we'll need to reinstate this service definition before any hotfixes are released to version `2.1` to avoid the Contextual Scoring Service from "disappearing" in their environments via a `plextrac update` command. 
