### PR TITLE
Bugfix/QOL: Rename Containers After Recreation

### DIFF
--- a/src/_rollout.sh
+++ b/src/_rollout.sh
@@ -131,6 +131,28 @@ mod_rollout() {
         docker stop "$OLD_CONTAINER_ID" > /dev/null 2>&1
         docker rm "$OLD_CONTAINER_ID" > /dev/null 2>&1
       done
+      counter=1
+      for NEW_CONTAINER_ID in "${NEW_CONTAINER_IDS[@]}"; do
+        # I want to check if the plextracapi containers are the current NEW_CONTAINER_ID
+        if [[ "$(docker inspect --format='{{json .Name}}' "$NEW_CONTAINER_ID" | grep -o 'plextracapi')" == "plextracapi" ]]; then
+          debug "Renaming container $NEW_CONTAINER_ID to plextrac-plextracapi-$counter"
+          docker rename "$NEW_CONTAINER_ID" "plextrac-plextracapi-$counter" > /dev/null 2>&1
+          (( counter++ ))
+          continue
+        elif [[ "$(docker inspect --format='{{json .Name}}' "$NEW_CONTAINER_ID" | grep -o 'notification-engine')" == "notification-engine" ]]; then
+          debug "Renaming container $NEW_CONTAINER_ID to plextrac-notification-engine-1"
+          docker rename "$NEW_CONTAINER_ID" "plextrac-notification-engine-1" > /dev/null 2>&1
+          continue
+        elif [[ "$(docker inspect --format='{{json .Name}}' "$NEW_CONTAINER_ID" | grep -o 'notification-sender')" == "notification-sender" ]]; then
+          debug "Renaming container $NEW_CONTAINER_ID to plextrac-notification-sender-1"
+          docker rename "$NEW_CONTAINER_ID" "plextrac-notification-sender-1" > /dev/null 2>&1
+          continue
+        elif [[ "$(docker inspect --format='{{json .Name}}' "$NEW_CONTAINER_ID" | grep -o 'datalake-maintainer')" == "datalake-maintainer" ]]; then
+          debug "Renaming container $NEW_CONTAINER_ID to plextrac-datalake-maintainer-1"
+          docker rename "$NEW_CONTAINER_ID" "plextrac-datalake-maintainer-1" > /dev/null 2>&1
+          continue
+        fi
+      done
     done
     info "Done!"
 }

--- a/src/_rollout.sh
+++ b/src/_rollout.sh
@@ -38,6 +38,7 @@ mod_rollout() {
     "notification-engine"
     "notification-sender"
     "plextracapi"
+    "contextual-scoring-service"
   )
 
   debug "$service_list"
@@ -150,6 +151,10 @@ mod_rollout() {
         elif [[ "$(docker inspect --format='{{json .Name}}' "$NEW_CONTAINER_ID" | grep -o 'datalake-maintainer')" == "datalake-maintainer" ]]; then
           debug "Renaming container $NEW_CONTAINER_ID to plextrac-datalake-maintainer-1"
           docker rename "$NEW_CONTAINER_ID" "plextrac-datalake-maintainer-1" > /dev/null 2>&1
+          continue
+        elif [[ "$(docker inspect --format='{{json .Name}}' "$NEW_CONTAINER_ID" | grep -o 'contextual-scoring-service')" == "contextual-scoring-service" ]]; then
+          debug "Renaming container $NEW_CONTAINER_ID to plextrac-contextual-scoring-service-1"
+          docker rename "$NEW_CONTAINER_ID" "plextrac-contextual-scoring-service-1" > /dev/null 2>&1
           continue
         fi
       done


### PR DESCRIPTION
# Tasks
- [x] Added way for containers to get renamed to prevent N sprawl on naming
- [x] This will also help metrics get tracked correctly by service name na dnot leave disconnected timeseries
- [x] Added handling for container scaling for the contextual scoring service

# Testing
- [x] RHEL
- [x] Ubuntu
- [x] RL
- [x] CentOS