### PR TITLE
Bugfix: RHEL 7 Compatibility

### DIFF
--- a/src/_cli_common_utilities.sh
+++ b/src/_cli_common_utilities.sh
@@ -81,3 +81,14 @@ function _load_static() {
     export SYSTEM_REQUIREMENTS=`cat "$staticFilesDir/system-requirements.json"`
   fi
 }
+
+function os_check() {
+  OS_NAME=$(grep '^NAME' /etc/os-release | cut -d '=' -f2)
+  OS_VERSION=$(grep '^VERSION_ID' /etc/os-release | cut -d '=' -f2)
+  color_always="--color=always"
+  if echo "$OS_NAME" | grep -q "Red"; then
+    if echo "$OS_VERSION" | grep -q "7"; then
+      color_always=""
+      fi
+  fi
+}

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -63,7 +63,8 @@ PLEXTRAC_BACKUP_PATH="${PLEXTRAC_BACKUP_PATH:-$PLEXTRAC_HOME/backups}"
     if [ $(echo "$mergedEnv" | md5sum | awk '{print $1}') = $(md5sum "${PLEXTRAC_HOME}/.env" | awk '{print $1}') ]; then
       log "No change required";
     else
-      envDiff="`diff -Nurb --color=always "${PLEXTRAC_HOME}/.env" <(echo "$mergedEnv") || true`"
+      os_check
+      envDiff="`diff -Nurb "$color_always" "${PLEXTRAC_HOME}/.env" <(echo "$mergedEnv") || true`"
       info "Detected pending changes to ${PLEXTRAC_HOME}/.env:"
       log "${envDiff}"
       if get_user_approval; then

--- a/src/_migrate.sh
+++ b/src/_migrate.sh
@@ -152,7 +152,8 @@ function checkExistingConfigForOverrides() {
 
   decodedComposeFile=$(base64 -d <<<$DOCKER_COMPOSE_ENCODED)
   #diff -N --unified=2 --color=always --label existing --label "updated" $targetComposeFile <(echo "$decodedComposeFile") || return 0
-  diff --unified --color=always --show-function-line='^\s\{2\}\w\+' \
+  os_check
+  diff --unified "$color_always" --show-function-line='^\s\{2\}\w\+' \
     <($dcCMD config --no-interpolate) \
     <(docker compose -f - <<< "${decodedComposeFile}" -f ${composeOverrideFile} config --no-interpolate) || return 0
   return 1

--- a/src/_setup_packages.sh
+++ b/src/_setup_packages.sh
@@ -18,10 +18,15 @@ function system_packages__refresh_package_lists() {
 function system_packages__do_system_upgrade() {
   info "Updating OS packages, this make take some time!"
   nobest="--nobest"
-  if [ "$(grep '^NAME' /etc/os-release | cut -d '=' -f2 | grep CentOS)" ]; then
+  os_check
+  if echo "$OS_NAME" | grep -q 'CentOS'; then
     nobest=""
-  elif [ "$(grep '^NAME' /etc/os-release | cut -d '=' -f2 | grep Hat)" ]; then
-    nobest="--nobest"
+  elif echo "$OS_NAME"  | grep -q 'Hat'; then
+    if echo "$OS_VERSION" | grep -v '7'; then
+      nobest="--nobest"
+    else
+      nobest=""
+    fi
   fi
   debug "$(grep '^NAME' /etc/os-release | cut -d '=' -f2 | tr -d '"')"
   system_packages__refresh_package_lists


### PR DESCRIPTION
- Updated OS Check to validate for RHEL 7 and remove command non-existent in older packages
  -  Specifically around the `diff` command and the `--nobest` flag for `yum`