### PR TITLE
Fixed and updated logic for upstream tag

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.4
+current_version = 0.5.5
 commit = True
 tag = True
 

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -144,7 +144,7 @@ function version_check() {
           # Set Contiguous updates to false here to ensure that since the app is on latest version, it still attempts to pull patch version updates
           contiguous_update=false
         fi
-        if [ "${upstream_tags[@]}" != "" ]; then
+        if [[ "${upstream_tags[@]}" != "" ]]; then
                 # Sort the upstream tags weve chosen as the upgrade path
                 IFS=$'\n' upgrade_path=($(sort -V <<<"${upstream_tags[*]}"))
                 # Reset IFS to default value

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.5.4
+VERSION=0.5.5
 
 trap 'cleanup $?' SIGINT ERR EXIT
 


### PR DESCRIPTION
Discovered bug in upstream_tag logic needing `[[ ... ]]` instead of `[ ... ]` for the test