### PR TITLE
Removes version from docker-compose configuration files

### DIFF
--- a/static/docker-compose.override.yml
+++ b/static/docker-compose.override.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+# version: '3.8'
 
 # Example configuration for adding a custom logo and/or using custom certificates
 # services:

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   plextracapi:
     deploy:


### PR DESCRIPTION
Docker has dropped support in latest release(s) for "version:" lines in the yaml configuration files. This PR removes those so that we are in line with latest expectations of docker-compose configuration files. 