### PR TITLE
Upgrade: Adding Podman support (0.6.0)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.5
+current_version = 0.6.0
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -61,17 +61,18 @@ Depending on your configuration, you may need to solve the following issues:
 #### *I'm unable to bind to port 443 with unprivileged user*
 
 - Add value to /etc/sysctl.conf and reload daemon
-> `net.ipv4.ip_unprivileged_port_start=443`
-> `sysctl --system`
+    > `net.ipv4.ip_unprivileged_port_start=443`
+    > `sysctl --system`
 
 #### *I'm using a SSH solution that doesn't directly create a user.slice with a login*
 
 - Enable service persistance after logout
-> `loginctl enable-linger plextrac`
+    > `loginctl enable-linger plextrac`
 
 #### *I can't execute out of `/tmp` folder*
+
 - Download PlexTrac Manager Utility with wget using this command:
-> `wget -O ~/plextrac -q https://github.com/PlexTrac/plextrac-manager-util/releases/latest/download/plextrac && sudo chmod a+x ~/plextrac && sudo bash ~/plextrac initialize -v -c podman`
+    > `wget -O ~/plextrac -q https://github.com/PlexTrac/plextrac-manager-util/releases/latest/download/plextrac && sudo chmod a+x ~/plextrac && sudo bash ~/plextrac initialize -v -c podman`
 
 #### My containers don't start after rebooting the host VM
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Now officially supported on:
 
 *Note: if running CentOS Stream 9, RHEL 9, or Rocky LInux 9, you'll need to use the PlexTrac version of Coucbase 7.2.0
 
-### Package Requirements:
+### Package Requirements
 
 The following system packages are used by and install by this application:
 | Package | Version|
@@ -41,97 +41,3 @@ The following system packages are used by and install by this application:
 | docker-ce-cli | >=v26.0.0 |
 | containerd.io | >=1.6.28 |
 | docker-compose-plugin | ~v2.24 |
-| podman | >=v4.6 (RHEL 9 only) |
-
-## Podman support
-
-We've expanded the capabilities to support podman in specific circumstances.
-
-*OS:* RHEL 9+
-*Podman Compose:* No (currently)
-
-> Note: the module for podman was written with RHEL 9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.
-
----
-
-### Podman Troubleshooting
-
-Depending on your configuration, you may need to solve the following issues:
-
-#### *I'm unable to bind to port 443 with unprivileged user*
-
-- Add value to /etc/sysctl.conf and reload daemon
-    > `net.ipv4.ip_unprivileged_port_start=443`
-    > `sysctl --system`
-
-#### *I'm unable to use Let's Encrypt for SSL Certificate*
-
-- Adjust the `/etc/sysctl.conf` value to start at `80` instead of `443`
-    > `net.ipv4.ip_unprivileged_port_start=80`
-    > `sysctl --system`
-
-#### *I'm using a SSH solution that doesn't directly create a user.slice with a login*
-
-- Enable service persistance after logout
-    > `loginctl enable-linger plextrac`
-
-#### *I can't execute out of `/tmp` folder*
-
-- Download PlexTrac Manager Utility with wget using this command:
-    > `wget -O ~/plextrac -q https://github.com/PlexTrac/plextrac-manager-util/releases/latest/download/plextrac && sudo chmod a+x ~/plextrac && sudo bash ~/plextrac initialize -v -c podman`
-
-#### My containers don't start after rebooting the host VM
-
-- For setting up container persistence: https://www.redhat.com/sysadmin/container-systemd-persist-reboot
-- The recommended method to start the PlexTrac containers is `plextrac start` after a reboot of the host OS
-
-
-#### RHEL 8 Support
-
-The following will need to be done before running any PlexTrac specific commands:
-
-- Edit `/etc/default/grub` and enable `cgroup v2`
-
-    ```bash
-    vim /etc/default/grub
-
-    # Add the following line and then save
-    systemd.unified_cgroup_hierarchy=1
-
-    # From CLI, run:
-    grub-mkconfig -o /boot/grub/grub.cfg
-    yum install netavark
-    # If not already enabled, run
-    yum module enable container-tools
-
-    # Enabling netavark over CNI
-    # As Root:
-    cp /usr/share/containers/containers.conf /etc/containers/
-    vim /etc/containers/containers.conf
-    ...
-    [network]
-    network_backend="netavark"
-    ...
-    podman system reset -f
-
-    # Finish setting up cgroups v2
-    sudo mkdir -p /etc/systemd/system/user@.service.d
-    cat <<EOF | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
-    [Service]
-    Delegate=cpu cpuset io memory pids
-    EOF
-    sudo systemctl daemon-reload
-
-    reboot
-    ```
-
-### Sources
-
----
-`cgroup2` configuration: <https://rootlesscontaine.rs/getting-started/common/cgroup2/>
-
----
-`netavark` configuration: <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_setting-container-network-modes_building-running-and-managing-containers#proc_switching-the-network-stack-from-cni-to-netavark_assembly_setting-container-network-modes>
-
----
-Service Persistance: <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_porting-containers-to-systemd-using-podman_building-running-and-managing-containers>

--- a/README.md
+++ b/README.md
@@ -43,11 +43,37 @@ The following system packages are used by and install by this application:
 | docker-compose-plugin | ~v2.24 |
 | podman | >=v4.6 (RHEL 9 only) |
 
-### Podman support
+## Podman support
 
-We've expanded the capabilities to support podman in specific  circumstances.
+We've expanded the capabilities to support podman in specific circumstances.
 
 *OS:* RHEL 9+
 *Podman Compose:* No (currently)
 
-*Note: the module for podman was written with RHEL 9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.
+> Note: the module for podman was written with RHEL 9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.
+
+---
+
+### Podman Troubleshooting
+
+Depending on your configuration, you may need to solve the following issues:
+
+#### *I'm unable to bind to port 443 with unprivileged user*
+
+- Add value to /etc/sysctl.conf and reload daemon
+> `net.ipv4.ip_unprivileged_port_start=443`
+> `sysctl --system`
+
+#### *I'm using a SSH solution that doesn't directly create a user.slice with a login*
+
+- Enable service persistance after logout
+> `loginctl enable-linger plextrac`
+
+#### *I can't execute out of `/tmp` folder*
+- Download PlexTrac Manager Utility with wget using this command:
+> `wget -O ~/plextrac -q https://github.com/PlexTrac/plextrac-manager-util/releases/latest/download/plextrac && sudo chmod a+x ~/plextrac && sudo bash ~/plextrac initialize -v -c podman`
+
+#### My containers don't start after rebooting the host VM
+
+- For setting up container persistence: https://www.redhat.com/sysadmin/container-systemd-persist-reboot
+- The recommended method to start the PlexTrac containers is `plextrac start` after a reboot of the host OS

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following system packages are used by and install by this application:
 | docker-ce-cli | >=v26.0.0 |
 | containerd.io | >=1.6.28 |
 | docker-compose-plugin | ~v2.24 |
+| podman | >=v4.6 (RHEL 9 only) |
 
 ### Podman support
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Please refer to `docs/getting-started.md` for usage instructions.
 
 Please refer to `docs/development.md` for development setup and contribution instructions.
 
+## Support
+
 Now officially supported on:
 
 - Ubuntu 20.04 and 22.04
@@ -20,3 +22,31 @@ Now officially supported on:
 - Debian 11 and 12
 
 *Note: if running CentOS Stream 9, RHEL 9, or Rocky LInux 9, you'll need to use the PlexTrac version of Coucbase 7.2.0
+
+### Package Requirements:
+
+The following system packages are used by and install by this application:
+| Package | Version|
+| -- | -- |
+| jq | v1-6 |
+| bc | all |
+| bash | v5+ |
+| apt-transport-https | all |
+| ca-certificates | all |
+| wget | all |
+| gnupg-agent | all |
+| software-properties-common | all (Debian) |
+| unzip | all |
+| docker-ce | >=v26.0.0 |
+| docker-ce-cli | >=v26.0.0 |
+| containerd.io | >=1.6.28 |
+| docker-compose-plugin | ~v2.24 |
+
+### Podman support
+
+We've expanded the capabilities to support podman in specific  circumstances.
+
+*OS:* RHEL 9+
+*Podman Compose:* No (currently)
+
+*Note: the module for podman was written with RHEL 9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -44,7 +44,6 @@ Depending on your configuration, you may need to solve the following issues:
 - For setting up container persistence: https://www.redhat.com/sysadmin/container-systemd-persist-reboot
 - The recommended method to start the PlexTrac containers is `plextrac start` after a reboot of the host OS
 
-
 #### RHEL 8 Support
 
 The following will need to be done before running any PlexTrac specific commands:
@@ -58,11 +57,18 @@ The following will need to be done before running any PlexTrac specific commands
     systemd.unified_cgroup_hierarchy=1
 
     # From CLI, run:
-    grub-mkconfig -o /boot/grub/grub.cfg
+    grub2-mkconfig -o /boot/grub2/grub.cfg
     yum install netavark
     # If not already enabled, run
     yum module enable container-tools
 
+    # Install Podman
+    yum install -y podman podman-plugins
+
+    # Add value to /etc/sysctl.conf and reload daemon
+    net.ipv4.ip_unprivileged_port_start=443
+    sysctl --system
+    
     # Enabling netavark over CNI
     # As Root:
     cp /usr/share/containers/containers.conf /etc/containers/
@@ -79,8 +85,8 @@ The following will need to be done before running any PlexTrac specific commands
     [Service]
     Delegate=cpu cpuset io memory pids
     EOF
-    sudo systemctl daemon-reload
 
+    sudo systemctl daemon-reload
     reboot
     ```
 

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -1,0 +1,96 @@
+## Additional Package Requirements
+
+podman | >=v4.6 (RHEL 8/9 only)
+
+## Podman support
+
+We've expanded the capabilities to support podman in specific circumstances.
+
+*OS:* RHEL 8/9+
+*Podman Compose:* No (currently)
+
+> Note: the module for podman was written with RHEL 9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.
+
+---
+
+### Podman Troubleshooting
+
+Depending on your configuration, you may need to solve the following issues:
+
+#### *I'm unable to bind to port 443 with unprivileged user*
+
+- Add value to /etc/sysctl.conf and reload daemon
+    > `net.ipv4.ip_unprivileged_port_start=443`
+    > `sysctl --system`
+
+#### *I'm unable to use Let's Encrypt for SSL Certificate*
+
+- Adjust the `/etc/sysctl.conf` value to start at `80` instead of `443`
+    > `net.ipv4.ip_unprivileged_port_start=80`
+    > `sysctl --system`
+
+#### *I'm using a SSH solution that doesn't directly create a user.slice with a login*
+
+- Enable service persistance after logout
+    > `loginctl enable-linger plextrac`
+
+#### *I can't execute out of `/tmp` folder*
+
+- Download PlexTrac Manager Utility with wget using this command:
+    > `wget -O ~/plextrac -q https://github.com/PlexTrac/plextrac-manager-util/releases/latest/download/plextrac && sudo chmod a+x ~/plextrac && sudo bash ~/plextrac initialize -v -c podman`
+
+#### My containers don't start after rebooting the host VM
+
+- For setting up container persistence: https://www.redhat.com/sysadmin/container-systemd-persist-reboot
+- The recommended method to start the PlexTrac containers is `plextrac start` after a reboot of the host OS
+
+
+#### RHEL 8 Support
+
+The following will need to be done before running any PlexTrac specific commands:
+
+- Edit `/etc/default/grub` and enable `cgroup v2`
+
+    ```bash
+    vim /etc/default/grub
+
+    # Add the following line and then save
+    systemd.unified_cgroup_hierarchy=1
+
+    # From CLI, run:
+    grub-mkconfig -o /boot/grub/grub.cfg
+    yum install netavark
+    # If not already enabled, run
+    yum module enable container-tools
+
+    # Enabling netavark over CNI
+    # As Root:
+    cp /usr/share/containers/containers.conf /etc/containers/
+    vim /etc/containers/containers.conf
+    ...
+    [network]
+    network_backend="netavark"
+    ...
+    podman system reset -f
+
+    # Finish setting up cgroups v2
+    sudo mkdir -p /etc/systemd/system/user@.service.d
+    cat <<EOF | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
+    [Service]
+    Delegate=cpu cpuset io memory pids
+    EOF
+    sudo systemctl daemon-reload
+
+    reboot
+    ```
+
+### Sources
+
+---
+`cgroup2` configuration: <https://rootlesscontaine.rs/getting-started/common/cgroup2/>
+
+---
+`netavark` configuration: <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_setting-container-network-modes_building-running-and-managing-containers#proc_switching-the-network-stack-from-cni-to-netavark_assembly_setting-container-network-modes>
+
+---
+Service Persistance: <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/building_running_and_managing_containers/assembly_porting-containers-to-systemd-using-podman_building-running-and-managing-containers>

--- a/src/_autocomplete.sh
+++ b/src/_autocomplete.sh
@@ -1,8 +1,9 @@
 function mod_autocomplete() {
   info "Configuring plextrac CLI autocomplete..."
-  if [ ! -f "${PLEXTRAC_HOME}/.bash_completion.d" ]; then
+  shelltype=$(echo $SHELL | rev | cut -d '/' -f1 | rev)
+  if [ ! -f "${PLEXTRAC_HOME}/.cli_completion.d" ]; then
     debug "Creating autocomplete directory"
-    mkdir -p "${PLEXTRAC_HOME}/.bash_completion.d"
+    mkdir -p "${PLEXTRAC_HOME}/.cli_completion.d"
   fi
   if [ -f "${PLEXTRAC_HOME}/.local/bin/plextrac" ]; then
     command_list="$(grep -E "function mod" ${PLEXTRAC_HOME}/.local/bin/plextrac | cut -d ' ' -f2 | cut -d '_' -f2 | cut -d '(' -f1 | grep -v etl)"
@@ -14,20 +15,20 @@ function mod_autocomplete() {
 }
 complete -F _plextrac plextrac"
 
-    bashrc_content='
-if [ -d ~/.bash_completion.d ]; then
-  for ac in ~/.bash_completion.d/*; do
+    shellrc_content='
+if [ -d ~/.cli_completion.d ]; then
+  for ac in ~/.cli_completion.d/*; do
     if [ -f "$ac" ]; then
       . "$ac"
     fi
   done
 fi
 unset ac'
-    debug "`echo \"${plextrac_compgen}\" > ${PLEXTRAC_HOME}/.bash_completion.d/plextrac`"
-    if grep -q ".bash_completion.d" "${PLEXTRAC_HOME}/.bashrc"; then
-      debug "bash_completion.d already sourced in ${PLEXTRAC_HOME}/.bashrc"
+    debug "`echo \"${plextrac_compgen}\" > ${PLEXTRAC_HOME}/.cli_completion.d/plextrac`"
+    if grep -q ".cli_completion.d" "${PLEXTRAC_HOME}/.${shelltype}rc"; then
+      debug "bash_completion.d already sourced in ${PLEXTRAC_HOME}/.${shelltype}rc"
     else
-      debug "`echo "${bashrc_content}" >> "${PLEXTRAC_HOME}/.bashrc"`"
+      debug "`echo "${shellrc_content}" >> "${PLEXTRAC_HOME}/.${shelltype}rc"`"
     fi
   else
     error "plextrac CLI not found in ${PLEXTRAC_HOME}/.local/bin/plextrac"

--- a/src/_autocomplete.sh
+++ b/src/_autocomplete.sh
@@ -1,0 +1,36 @@
+function mod_autocomplete() {
+  info "Configuring plextrac CLI autocomplete..."
+  if [ ! -f "${PLEXTRAC_HOME}/.bash_completion.d" ]; then
+    debug "Creating autocomplete directory"
+    mkdir -p "${PLEXTRAC_HOME}/.bash_completion.d"
+  fi
+  if [ -f "${PLEXTRAC_HOME}/.local/bin/plextrac" ]; then
+    command_list="$(grep -E "function mod" ${PLEXTRAC_HOME}/.local/bin/plextrac | cut -d ' ' -f2 | cut -d '_' -f2 | cut -d '(' -f1 | grep -v etl)"
+    command_list=$(echo -n $command_list | tr '\n' ' ' | sed 's/ $//')
+    plextrac_compgen="_plextrac()
+{
+  local cur=\${COMP_WORDS[COMP_CWORD]}
+  COMPREPLY=( \$(compgen -W \"$command_list\" -- \$cur) )
+}
+complete -F _plextrac plextrac"
+
+    bashrc_content='
+if [ -d ~/.bash_completion.d ]; then
+  for ac in ~/.bash_completion.d/*; do
+    if [ -f "$ac" ]; then
+      . "$ac"
+    fi
+  done
+fi
+unset ac'
+    debug "`echo \"${plextrac_compgen}\" > ${PLEXTRAC_HOME}/.bash_completion.d/plextrac`"
+    if grep -q ".bash_completion.d" "${PLEXTRAC_HOME}/.bashrc"; then
+      debug "bash_completion.d already sourced in ${PLEXTRAC_HOME}/.bashrc"
+    else
+      debug "`echo "${bashrc_content}" >> "${PLEXTRAC_HOME}/.bashrc"`"
+    fi
+  else
+    error "plextrac CLI not found in ${PLEXTRAC_HOME}/.local/bin/plextrac"
+  fi
+  info "Done. Logout and back in to use autocomplete."    
+}

--- a/src/_backup.sh
+++ b/src/_backup.sh
@@ -7,7 +7,7 @@ function mod_backup() {
   backup_ensureBackupDirectory
   backup_fullPostgresBackup
   backup_fullCouchbaseBackup
-  backup_fullUploadsBackup
+  backup_fullUploadsBackup "svcValues"
 }
 
 function backup_ensureBackupDirectory() {
@@ -19,21 +19,39 @@ function backup_ensureBackupDirectory() {
 }
 
 function backup_fullUploadsBackup() {
+  var=$(declare -p "$1")
+  eval "declare -A serviceValues="${var#*=}
   # Yoink uploads out to a compressed tarball
   info "$coreBackendComposeService: Performing backup of uploads directory"
   uploadsBackupDir="${PLEXTRAC_BACKUP_PATH}/uploads"
   mkdir -p $uploadsBackupDir
-  debug "`compose_client run --user 1337 -v ${uploadsBackupDir}:/backups \
-    --workdir /usr/src/plextrac-api --rm --entrypoint='' -T  $coreBackendComposeService \
-    tar -czf /backups/$(date -u "+%Y-%m-%dT%H%M%Sz").tar.gz uploads`"
+ if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    local current_date=$(date -u "+%Y-%m-%dT%H%M%Sz")
+    podman exec --workdir="/usr/src/plextrac-api" plextracapi tar -czf "uploads/$current_date.tar.gz" uploads
+    debug "Archiving uploads succeeded"
+    podman cp plextracapi:/usr/src/plextrac-api/uploads/$current_date.tar.gz $uploadsBackupDir
+    debug "Copying to host succeeded"
+    podman exec --workdir="/usr/src/plextrac-api/uploads" plextracapi rm $current_date.tar.gz
+    debug "Cleaned Archive from container"
+  else
+    debug "`compose_client run --user 1337 -v ${uploadsBackupDir}:/backups \
+      --workdir /usr/src/plextrac-api --rm --entrypoint='' -T  $coreBackendComposeService \
+      tar -czf /backups/$(date -u "+%Y-%m-%dT%H%M%Sz").tar.gz uploads`"
+  fi
   log "Done."
 }
 
 function backup_fullCouchbaseBackup() {
   info "$couchbaseComposeService: Performing backup of couchbase database"
-  debug "`compose_client exec -T $couchbaseComposeService \
-    chown -R 1337:1337 /backups 2>&1`"
-  debug "`compose_client exec -T --user 1337 $couchbaseComposeService \
+  local cmd='compose_client exec -T --user 1337'
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    cmd='docker exec'
+  fi
+  if [ "$CONTAINER_RUNTIME" != "podman" ]; then
+    debug "`$cmd $couchbaseComposeService \
+      chown -R 1337:1337 /backups 2>&1`"
+  fi
+  debug "`$cmd $couchbaseComposeService \
     cbbackup -m full "http://127.0.0.1:8091" /backups -u ${CB_BACKUP_USER} -p ${CB_BACKUP_PASS} 2>&1`"
   latestBackup=`ls -dc1 ${PLEXTRAC_BACKUP_PATH}/couchbase/* | head -n1`
   backupDir=`basename $latestBackup`
@@ -44,20 +62,24 @@ function backup_fullCouchbaseBackup() {
 
 function backup_fullPostgresBackup() {
   info "$postgresComposeService: Performing backup of postgres database"
-  debug "`compose_client exec -T $postgresComposeService \
-    chown -R 1337:1337 /backups 2>&1`"
+  local cmd='compose_client exec -T --user 1337'
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    cmd='docker exec'
+  fi
+  if [ "$CONTAINER_RUNTIME" != "podman" ]; then
+    debug "`compose_client exec -T $postgresComposeService chown -R 1337:1337 /backups 2>&1`"
+  fi
   backupTimestamp=$(date -u "+%Y-%m-%dT%H%M%Sz")
   targetPath=/backups/$backupTimestamp
-  debug "`compose_client exec -T --user 1337 $postgresComposeService mkdir -p $targetPath`"
+  debug "`$cmd $postgresComposeService mkdir -p $targetPath`"
   pgBackupFlags='--format=custom --compress=1 --verbose'
   for db in ${postgresDatabases[@],,}; do
     log "Backing up $db to $targetPath"
-    debug "`compose_client exec -T --user 1337 -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
+    debug "`$cmd -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
       pg_dump -U $POSTGRES_USER $db $pgBackupFlags --file=$targetPath/$db.psql 2>&1`"
   done
   debug "Compressing Postgres backup"
-  debug "`tar -C ${PLEXTRAC_BACKUP_PATH}/postgres/$backupTimestamp --remove-files -czvf \
-    ${PLEXTRAC_BACKUP_PATH}/postgres/$backupTimestamp.tar.gz .`"
+  tar -C ${PLEXTRAC_BACKUP_PATH}/postgres/$backupTimestamp --remove-files -czvf ${PLEXTRAC_BACKUP_PATH}/postgres/$backupTimestamp.tar.gz .
   log "Done"
 }
 

--- a/src/_cli_common_utilities.sh
+++ b/src/_cli_common_utilities.sh
@@ -86,9 +86,17 @@ function os_check() {
   OS_NAME=$(grep '^NAME' /etc/os-release | cut -d '=' -f2)
   OS_VERSION=$(grep '^VERSION_ID' /etc/os-release | cut -d '=' -f2)
   color_always="--color=always"
-  if echo "$OS_NAME" | grep -q "Red"; then
-    if echo "$OS_VERSION" | grep -q "7"; then
+  if grep -q "Red" <(echo "$OS_NAME"); then
+    if grep -q "7." <(echo "$OS_VERSION"); then
       color_always=""
       fi
+  fi
+}
+
+function check_container_runtime() {
+  if [ "$CONTAINER_RUNTIME" == "docker" ]; then debug "Using Docker and Docker Compose as the container runtime";
+  elif [ "$CONTAINER_RUNTIME" == "podman" ]; then debug "Using Podman as the container runtime"; 
+  elif [ "$CONTAINER_RUNTIME" == "podman-compose" ]; then die "Using Podman-Compose is still currently unsupported";
+  else error "Unknown container runtime: $CONTAINER_RUNTIME"; die "Valid container runtimes are: docker, podman, podman-compose";
   fi
 }

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -187,9 +187,13 @@ function create_volume_directories() {
   if [ "$CONTAINER_RUNTIME" != "podman" ]; then
     debug "`compose_client config --format=json | jq '.volumes[] | .driver_opts.device | select(.)' | xargs -r mkdir -vp`"
   else
-    stat "${PLEXTRAC_BACKUP_PATH}/couchbase" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/couchbase"
+    stat "${PLEXTRAC_BACKUP_PATH}/couchbase" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/couchase"
     stat "${PLEXTRAC_BACKUP_PATH}/postgres" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/postgres"
     stat "${PLEXTRAC_BACKUP_PATH}/uploads" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/uploads"
+    stat "${PLEXTRAC_HOME}/volumes" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes"
+    stat "${PLEXTRAC_HOME}/volumes/postgres-initdb" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/postgres-initdb"
+    stat "${PLEXTRAC_HOME}/volumes/redis" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/redis"
+    stat "${PLEXTRAC_HOME}/volumes/datalake-maintainer-keys/couchbase" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/datalake-maintainer-keys"
   fi
   info "Validating directories for bind mounts"
   log "Done."

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -200,6 +200,8 @@ function create_volume_directories() {
     stat "${PLEXTRAC_HOME}/volumes" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes"
     stat "${PLEXTRAC_HOME}/volumes/postgres-initdb" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/postgres-initdb"
     stat "${PLEXTRAC_HOME}/volumes/redis" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/redis"
+    stat "${PLEXTRAC_HOME}/volumes/nginx_ssl_certs" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/nginx_ssl_certs"
+    stat "${PLEXTRAC_HOME}/volumes/nginx_logos" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/nginx_logos"
   fi
 }
 

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -183,19 +183,17 @@ function validateComposeConfig() {
 
 function create_volume_directories() {
   title "Create directories for bind mounts"
+  info "Validating directories for bind mounts"
   debug "Ensuring directories exist for Volumes..."
   if [ "$CONTAINER_RUNTIME" != "podman" ]; then
     debug "`compose_client config --format=json | jq '.volumes[] | .driver_opts.device | select(.)' | xargs -r mkdir -vp`"
   else
-    stat "${PLEXTRAC_BACKUP_PATH}/couchbase" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/couchase"
+    stat "${PLEXTRAC_BACKUP_PATH}/couchbase" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/couchbase"
     stat "${PLEXTRAC_BACKUP_PATH}/postgres" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/postgres"
     stat "${PLEXTRAC_BACKUP_PATH}/uploads" &>/dev/null || mkdir -vp "${PLEXTRAC_BACKUP_PATH}/uploads"
     stat "${PLEXTRAC_HOME}/volumes" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes"
     stat "${PLEXTRAC_HOME}/volumes/postgres-initdb" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/postgres-initdb"
     stat "${PLEXTRAC_HOME}/volumes/redis" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/redis"
-    stat "${PLEXTRAC_HOME}/volumes/datalake-maintainer-keys/couchbase" &>/dev/null || mkdir -vp "${PLEXTRAC_HOME}/volumes/datalake-maintainer-keys"
   fi
-  info "Validating directories for bind mounts"
-  log "Done."
 }
 

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -127,12 +127,10 @@ function login_dockerhub() {
     if [ -z "${IMAGE_REGISTRY_PASS:-}" ]; then
       debug "$IMAGE_REGISTRY password not found, continuing..."
       local image_pass=""
-      docker login ${IMAGE_REGISTRY} $image_user || die "Failed to login to ${IMAGE_REGISTRY}"
+      container_client login ${IMAGE_REGISTRY} $image_user || die "Failed to login to ${IMAGE_REGISTRY}"
     else
-      docker login ${IMAGE_REGISTRY} $image_user --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}" || die "Failed to login to ${IMAGE_REGISTRY}"
+      container_client login ${IMAGE_REGISTRY} $image_user --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}" || die "Failed to login to ${IMAGE_REGISTRY}"
     fi
-    output="$(container_client login ${IMAGE_REGISTRY} -u ${IMAGE_REGISTRY_USER} --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}")" || die "${output}"
-    debug "$output"
     log "${BLUE}$IMAGE_REGISTRY${RESET}: SUCCESS"
   fi
   log "Done."

--- a/src/_docker_manager.sh
+++ b/src/_docker_manager.sh
@@ -7,9 +7,26 @@ postgresComposeService="postgres"
 function compose_client() {
   flags=($@)
   compose_files=$(for i in `ls -r ${PLEXTRAC_HOME}/docker-compose*.yml`; do printf " -f %s" "$i"; done )
-  debug "docker compose flags: ${flags[@]}"
-  debug "docker compose configs: ${compose_files}"
-  docker compose $(echo $compose_files) ${flags[@]}
+  if [ "$CONTAINER_RUNTIME" == "podman-compose" ] || [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    debug "podman-compose flags: ${flags[@]}"
+    debug "podman-compose configs: ${compose_files}"
+    podman-compose $(echo $compose_files) ${flags[@]}
+  elif [ "$CONTAINER_RUNTIME" == "docker" ]; then
+    debug "docker compose flags: ${flags[@]}"
+    debug "docker compose configs: ${compose_files}"
+    docker compose $(echo $compose_files) ${flags[@]}
+  fi
+}
+
+function container_client() {
+  flags=($@)
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    debug "podman flags: ${flags[@]}"
+    podman ${flags[@]}
+  elif [ "$CONTAINER_RUNTIME" == "docker" ]; then
+    debug "docker flags: ${flags[@]}"
+    docker ${flags[@]}
+  fi
 }
 
 function image_version_check() {

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -32,7 +32,7 @@ function configure_user_environment() {
 
 function copy_scripts() {
   info "Copying plextrac CLI to user PATH..."
-  tmp=`mktemp -p /tmp plextrac-XXX`
+  tmp=`mktemp -p ~/tmp plextrac-XXX`
   debug "tmp script location: $tmp"
   debug "`$0 dist 2>/dev/null > $tmp && cp -uv $tmp "${PLEXTRAC_HOME}/.local/bin/plextrac"`"
   chmod +x "${PLEXTRAC_HOME}/.local/bin/plextrac"

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -4,11 +4,18 @@ function create_user() {
   if ! id -u "plextrac" >/dev/null 2>&1
   then
     info "Adding plextrac user..."
-    useradd --uid 1337 \
-            --groups docker \
-            --shell /bin/bash \
-            --create-home --home "${PLEXTRAC_HOME}" \
-            plextrac
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      useradd --uid 1337 \
+              --shell /bin/bash \
+              --create-home --home "${PLEXTRAC_HOME}" \
+              plextrac
+    else
+      useradd --uid 1337 \
+              --groups docker \
+              --shell /bin/bash \
+              --create-home --home "${PLEXTRAC_HOME}" \
+              plextrac
+    fi
     log "Done."
   fi
 }
@@ -32,7 +39,7 @@ function configure_user_environment() {
 
 function copy_scripts() {
   info "Copying plextrac CLI to user PATH..."
-  tmp=`mktemp -p ~/tmp plextrac-XXX`
+  tmp=`mktemp -p ~/ plextrac-XXX`
   debug "tmp script location: $tmp"
   debug "`$0 dist 2>/dev/null > $tmp && cp -uv $tmp "${PLEXTRAC_HOME}/.local/bin/plextrac"`"
   chmod +x "${PLEXTRAC_HOME}/.local/bin/plextrac"
@@ -43,4 +50,4 @@ function fix_file_ownership() {
   info "Fixing file ownership in ${PLEXTRAC_HOME} for plextrac"
   chown -R plextrac:plextrac "${PLEXTRAC_HOME}"
   log "Done."
-}
+} 

--- a/src/_logs.sh
+++ b/src/_logs.sh
@@ -7,5 +7,9 @@ function mod_logs() {
 }
 
 function tail_logs() {
-    compose_client logs -f --tail=50 ${LOG_SERVICE-''}
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    container_client logs -f --tail=200 ${LOG_SERVICE-''}
+  else
+    compose_client logs -f --tail=200 ${LOG_SERVICE-''}
+  fi
 }

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -100,11 +100,11 @@ function postgres_metrics_validation() {
   if [ "${PG_METRICS_USER:-}" != "" ]; then
     info "Checking user $PG_METRICS_USER can access postgres metrics"
     if [ "$CONTAINER_RUNTIME" != "podman" ]; then
-      local container_runtime="compose_client exec -T"
+      local container_runtime="compose_client exec -T -u 1337"
     else
       local container_runtime="container_client exec"
     fi
-    debug "`$container_runtime -u 1337 -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
+    debug "`$container_runtime -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
         psql -a -v -U internalonly -d core 2>&1 <<- EOF 
 CREATE OR REPLACE FUNCTION __tmp_create_user() returns void as \\$\\$
 BEGIN

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -23,7 +23,7 @@ ENDPOSTGRES
 function deploy_volume_contents_postgres() {
   debug "Adding postgres initdb scripts to volume mount"
   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-    targetDir="${PLEXTRAC_HOME}/.local/share/containers/storage/volumes/postgres-initdb/_data"
+    targetDir="${PLEXTRAC_HOME}/volumes/postgres-initdb"
   else
     targetDir=`compose_client config --format=json | jq -r \
       '.volumes[] | select(.name | test("postgres-initdb")) | 

--- a/src/_migrate.sh
+++ b/src/_migrate.sh
@@ -13,7 +13,8 @@
 # Usage:
 #   plextrac migrate [-y] [--plextrac-home ...]
 
-function mod_migrate() {
+function deprecated_migrate() {
+  die "This module is deprecated and is no longer functional"
   title "Migrating Existing Instance"
   docker_createInitialComposeOverrideFile
 

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -43,6 +43,7 @@ function plextrac_install_podman() {
   else
     serviceValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
   fi
+  serviceValues[migrations-env_vars]="-e COUCHBASE_URL=${COUCHBASE_URL:-http://plextracdb} -e CB_API_PASS=${CB_API_PASS} -e CB_API_USER=${CB_API_USER} -e REDIS_CONNECTION_STRING=${REDIS_CONNECTION_STRING:-redis} -e REDIS_PASSWORD=${REDIS_PASSWORD:?err} -e PG_HOST=${PG_HOST:-postgres} -e PG_MIGRATE_PATH=/usr/src/plextrac-api -e PG_SUPER_USER=${POSTGRES_USER:?err} -e PG_SUPER_PASSWORD=${POSTGRES_PASSWORD:?err} -e PG_CORE_ADMIN_PASSWORD=${PG_CORE_ADMIN_PASSWORD:?err} -e PG_CORE_ADMIN_USER=${PG_CORE_ADMIN_USER:?err} -e PG_CORE_DB=${PG_CORE_DB:?err} -e PG_RUNBOOKS_ADMIN_PASSWORD=${PG_RUNBOOKS_ADMIN_PASSWORD:?err} -e PG_RUNBOOKS_ADMIN_USER=${PG_RUNBOOKS_ADMIN_USER:?err} -e PG_RUNBOOKS_RW_PASSWORD=${PG_RUNBOOKS_RW_PASSWORD:?err} -e PG_RUNBOOKS_RW_USER=${PG_RUNBOOKS_RW_USER:?err} -e PG_RUNBOOKS_DB=${PG_RUNBOOKS_DB:?err} -e PG_CKEDITOR_ADMIN_PASSWORD=${PG_CKEDITOR_ADMIN_PASSWORD:?err} -e PG_CKEDITOR_ADMIN_USER=${PG_CKEDITOR_ADMIN_USER:?err} -e PG_CKEDITOR_DB=${PG_CKEDITOR_DB:?err} -e PG_CKEDITOR_RO_PASSWORD=${PG_CKEDITOR_RO_PASSWORD:?err} -e PG_CKEDITOR_RO_USER=${PG_CKEDITOR_RO_USER:?err} -e PG_CKEDITOR_RW_PASSWORD=${PG_CKEDITOR_RW_PASSWORD:?err} -e PG_CKEDITOR_RW_USER=${PG_CKEDITOR_RW_USER:?err} -e PG_TENANTS_WRITE_MODE=${PG_TENANTS_WRITE_MODE:-couchbase_only} -e PG_TENANTS_READ_MODE=${PG_TENANTS_READ_MODE:-couchbase_only} -e PG_CORE_RO_PASSWORD=${PG_CORE_RO_PASSWORD:?err} -e PG_CORE_RO_USER=${PG_CORE_RO_USER:?err} -e PG_CORE_RW_PASSWORD=${PG_CORE_RW_PASSWORD:?err} -e PG_CORE_RW_USER=${PG_CORE_RW_USER:?err}"
   title "Installing PlexTrac Instance"
   requires_user_plextrac
   mod_configure
@@ -139,6 +140,7 @@ function plextrac_start_podman() {
   else
     serviceValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
   fi
+  serviceValues[migrations-env_vars]="-e COUCHBASE_URL=${COUCHBASE_URL:-http://plextracdb} -e CB_API_PASS=${CB_API_PASS} -e CB_API_USER=${CB_API_USER} -e REDIS_CONNECTION_STRING=${REDIS_CONNECTION_STRING:-redis} -e REDIS_PASSWORD=${REDIS_PASSWORD:?err} -e PG_HOST=${PG_HOST:-postgres} -e PG_MIGRATE_PATH=/usr/src/plextrac-api -e PG_SUPER_USER=${POSTGRES_USER:?err} -e PG_SUPER_PASSWORD=${POSTGRES_PASSWORD:?err} -e PG_CORE_ADMIN_PASSWORD=${PG_CORE_ADMIN_PASSWORD:?err} -e PG_CORE_ADMIN_USER=${PG_CORE_ADMIN_USER:?err} -e PG_CORE_DB=${PG_CORE_DB:?err} -e PG_RUNBOOKS_ADMIN_PASSWORD=${PG_RUNBOOKS_ADMIN_PASSWORD:?err} -e PG_RUNBOOKS_ADMIN_USER=${PG_RUNBOOKS_ADMIN_USER:?err} -e PG_RUNBOOKS_RW_PASSWORD=${PG_RUNBOOKS_RW_PASSWORD:?err} -e PG_RUNBOOKS_RW_USER=${PG_RUNBOOKS_RW_USER:?err} -e PG_RUNBOOKS_DB=${PG_RUNBOOKS_DB:?err} -e PG_CKEDITOR_ADMIN_PASSWORD=${PG_CKEDITOR_ADMIN_PASSWORD:?err} -e PG_CKEDITOR_ADMIN_USER=${PG_CKEDITOR_ADMIN_USER:?err} -e PG_CKEDITOR_DB=${PG_CKEDITOR_DB:?err} -e PG_CKEDITOR_RO_PASSWORD=${PG_CKEDITOR_RO_PASSWORD:?err} -e PG_CKEDITOR_RO_USER=${PG_CKEDITOR_RO_USER:?err} -e PG_CKEDITOR_RW_PASSWORD=${PG_CKEDITOR_RW_PASSWORD:?err} -e PG_CKEDITOR_RW_USER=${PG_CKEDITOR_RW_USER:?err} -e PG_TENANTS_WRITE_MODE=${PG_TENANTS_WRITE_MODE:-couchbase_only} -e PG_TENANTS_READ_MODE=${PG_TENANTS_READ_MODE:-couchbase_only} -e PG_CORE_RO_PASSWORD=${PG_CORE_RO_PASSWORD:?err} -e PG_CORE_RO_USER=${PG_CORE_RO_USER:?err} -e PG_CORE_RW_PASSWORD=${PG_CORE_RW_PASSWORD:?err} -e PG_CORE_RW_USER=${PG_CORE_RW_USER:?err}"
   
   title "Starting PlexTrac..."
   requires_user_plextrac
@@ -193,6 +195,7 @@ function plextrac_start_podman() {
         local deploy="" # update this
       elif [ "$service" == "migrations" ]; then
         local volumes="${serviceValues[migrations-volumes]}"
+        local env_vars="${serviceValues[migrations-env_vars]}"
       elif [ "$service" == "plextracnginx" ]; then
         local volumes="${serviceValues[plextracnginx-volumes]}"
         local ports="${serviceValues[plextracnginx-ports]}"

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -1,0 +1,274 @@
+function podman_setup() {
+  info "Configuring up PlexTrac with podman"
+  debug "Podman Network Configuration"
+  if container_client network exists plextrac; then
+    debug "Network plextrac already exists"
+  else
+    debug "Creating network plextrac"
+    container_client network create plextrac 1>/dev/null
+  fi
+  if container_client volume exists postgres-initdb; then
+    debug "Volume postgres-initdb already exists"
+  else
+    debug "Creating volume postgres-initdb"
+    container_client volume create postgres-initdb 1>/dev/null
+    deploy_volume_contents_postgres
+  fi
+  create_volume_directories
+
+  #####
+  # Placeholder for right now. These ENVs may need to be set in the .env file if we are using podman.
+  #####
+  #POSTGRES_HOST_AUTH_METHOD=scram-sha-256
+  #POSTGRES_INITDB_ARGS="--auth-local=scram-sha-256 --auth-host=scram-sha-256"
+  #PG_MIGRATE_PATH=/usr/src/plextrac-api
+  #PGDATA: /var/lib/postgresql/data/pgdata
+}
+
+function plextrac_install_podman() {
+  declare -A serviceValues
+
+  export POSTGRES_HOST_AUTH_METHOD=scram-sha-256
+  export POSTGRES_INITDB_ARGS="--auth-local=scram-sha-256 --auth-host=scram-sha-256"
+  export PG_MIGRATE_PATH=/usr/src/plextrac-api
+  export PGDATA=/var/lib/postgresql/data/pgdata
+
+  databaseNames=("plextracdb" "postgres")
+  serviceNames=("plextracdb" "postgres" "redis" "plextracapi" "notification-engine" "notification-sender" "contextual-scoring-service" "migrations" "plextracnginx")
+  serviceValues[network]="--network=plextrac"
+  serviceValues[env-file]="--env-file /opt/plextrac/.env"
+  serviceValues[cb-volumes]="-v dbdata:/opt/couchbase/var:rw -v couchbase-backups:/backups:rw"
+  serviceValues[cb-ports]="-p 127.0.0.1:8091-8094:8091-8094"
+  serviceValues[cb-healthcheck]=""
+  serviceValues[cb-image]="docker.io/plextrac/plextracdb:7.2.0"
+  serviceValues[pg-volumes]="-v postgres-initdb:/docker-entrypoint-initdb.d -v postgres-data:/var/lib/postgresql/data -v postgres-backups:/backups"
+  serviceValues[pg-ports]="-p 127.0.0.1::5432"
+  serviceValues[pg-healthcheck]=""
+  serviceValues[pg-image]="docker.io/postgres:14-alpine"
+  serviceValues[pg-env-vars]="-e 'POSTGRES_HOST_AUTH_METHOD' -e 'POSTGRES_INITDB_ARGS' -e 'PG_MIGRATE_PATH' -e 'PGDATA'"
+  serviceValues[api-volumes]="-v uploads:/usr/src/plextrac-api/uploads:rw -v datalake-maintainer-keys:/usr/src/plextrac-api/keys/gcp -v localesOverride:/usr/src/plextrac-api/localesOverride:rw"
+  serviceValues[api-healthcheck]=""
+  serviceValues[api-image]="docker.io/plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+  serviceValues[redis-volumes]="-v redis:/etc/redis:rw"
+  serviceValues[redis-entrypoint]=$(printf '%s%s%s%s%s%s%s%s' "--entrypoint=" "[" "\"redis-server\"" "," "\"--requirepass\"" "," "\"${REDIS_PASSWORD}\"" "]")
+  serviceValues[redis-image]="docker.io/redis:6.2-alpine"
+  serviceValues[notification-engine-entrypoint]='--entrypoint ["npm","run","start:notification-engine"]'
+  serviceValues[notification-sender-entrypoint]='--entrypoint ["npm","run","start:notification-sender"]'
+  serviceValues[contextual-scoring-service-entrypoint]='--entrypoint ["npm","run","start:contextual-scoring-service"]'
+  serviceValues[migrations-volumes]="-v uploads:/usr/src/plextrac-api/uploads:rw"
+  serviceValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
+  serviceValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
+  serviceValues[plextracnginx-image]="docker.io/plextrac/plextracnginx:${UPGRADE_STRATEGY:-stable}"
+
+  title "Installing PlexTrac Instance"
+  requires_user_plextrac
+  mod_configure
+  info "Starting Databases before other services"
+  # Check if DB running first, then start it.
+  debug "Handling Databases..."
+  for database in "${databaseNames[@]}"; do
+    debug "Checking $database"
+    if container_client container exists "$database"; then
+      debug "$database already exists"
+      # if database exists but isn't running
+      if [ "$(container_client container inspect --format '{{.State.Status}}' "$database")" != "running" ]; then
+        debug "Starting $database"
+        container_client start "$database" 1>/dev/null
+      else
+        debug "$database is already running"
+      fi
+    else
+      debug "Container doesn't exist. Creating $database"
+      if [ "$database" == "plextracdb" ]; then
+        local volumes=${serviceValues[cb-volumes]}
+        local ports="${serviceValues[cb-ports]}"
+        local healthcheck="${serviceValues[cb-healthcheck]}"
+        local image="${serviceValues[cb-image]}"
+        local env_vars=""
+      elif [ "$database" == "postgres" ]; then
+        local volumes="${serviceValues[pg-volumes]}"
+        local ports="${serviceValues[pg-ports]}"
+        local healthcheck="${serviceValues[pg-healthcheck]}"
+        local image="${serviceValues[pg-image]}"
+        local env_vars="${serviceValues[pg-env-vars]}"
+      fi
+      container_client run "${serviceValues[env-file]}" "$env_vars" --restart=always "$healthcheck" \
+        "$volumes" --name="${database}" "${serviceValues[network]}" "$ports" -d "$image" 1>/dev/null
+      info "Sleeping to give $database a chance to start up"
+      local progressBar
+      for i in `seq 1 10`; do
+        progressBar=`printf ".%.0s%s"  {1..$i} "${progressBar:-}"`
+        msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
+        sleep 2
+      done
+      >&2 echo -n "${RESET}"
+      log "Done"
+    fi
+  done
+  mod_autofix
+  if [ ${RESTOREONINSTALL:-0} -eq 1 ]; then
+    info "Restoring from backups"
+    log "Restoring databases first"
+    RESTORETARGET="couchbase" mod_restore
+    if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/postgres/)" ]; then
+      RESTORETARGET="postgres" mod_restore
+    else
+      debug "No postgres backups to restore"
+    fi
+    debug "Checking for uploads to restore"
+    if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/uploads/)" ]; then
+      log "Starting API to prepare for uploads restore"
+      if container_client container exists plextracapi; then
+        if [ "$(container_client container inspect --format '{{.State.Status}}' plextracapi)" != "running" ]; then
+          container_client start plextracapi 1>/dev/null
+        else
+          log "plextracapi is already running"
+        fi
+      else
+        debug "Creating plextracapi"
+        container_client run "${serviceValues[env-file]}" --restart=always "$healthcheck" \
+        "$volumes" --name="plextracapi" "${serviceValues[network]}" -d "${serviceValues[api-image]}" 1>/dev/null
+      fi
+      log "Restoring uploads"
+      RESTORETARGET="uploads" mod_restore
+    else
+      debug "No uploads to restore"
+    fi
+  fi
+  
+  mod_start "${INSTALL_WAIT_TIMEOUT:-600}" # allow up to 10 or specified minutes for startup on install, due to migrations
+  mod_info
+  info "Post installation note:"
+  log "If you wish to have access to historical logs, you can configure docker to send logs to journald."
+  log "Please see the config steps at"
+  log "https://docs.plextrac.com/plextrac-documentation/product-documentation-1/on-premise-management/setting-up-historical-logs"
+}
+
+function plextrac_start_podman() {
+  declare -A serviceValues
+
+  export POSTGRES_HOST_AUTH_METHOD=scram-sha-256
+  export POSTGRES_INITDB_ARGS="--auth-local=scram-sha-256 --auth-host=scram-sha-256"
+  export PG_MIGRATE_PATH=/usr/src/plextrac-api
+  export PGDATA=/var/lib/postgresql/data/pgdata
+
+  databaseNames=("plextracdb" "postgres")
+  serviceNames=("plextracdb" "postgres" "redis" "plextracapi" "notification-engine" "notification-sender" "contextual-scoring-service" "migrations" "plextracnginx")
+  serviceValues[network]="--network=plextrac"
+  serviceValues[env-file]="--env-file /opt/plextrac/.env"
+  serviceValues[cb-volumes]="-v dbdata:/opt/couchbase/var:rw -v couchbase-backups:/backups:rw"
+  serviceValues[cb-ports]="-p 127.0.0.1:8091-8094:8091-8094"
+  serviceValues[cb-healthcheck]=""
+  serviceValues[cb-image]="docker.io/plextrac/plextracdb:7.2.0"
+  serviceValues[pg-volumes]="-v postgres-initdb:/docker-entrypoint-initdb.d -v postgres-data:/var/lib/postgresql/data -v postgres-backups:/backups"
+  serviceValues[pg-ports]="-p 127.0.0.1::5432"
+  serviceValues[pg-healthcheck]=""
+  serviceValues[pg-image]="docker.io/postgres:14-alpine"
+  serviceValues[pg-env-vars]="-e 'POSTGRES_HOST_AUTH_METHOD' -e 'POSTGRES_INITDB_ARGS' -e 'PG_MIGRATE_PATH' -e 'PGDATA'"
+  serviceValues[api-volumes]="-v uploads:/usr/src/plextrac-api/uploads:rw -v datalake-maintainer-keys:/usr/src/plextrac-api/keys/gcp -v localesOverride:/usr/src/plextrac-api/localesOverride:rw"
+  serviceValues[api-healthcheck]=""
+  serviceValues[api-image]="docker.io/plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+  serviceValues[redis-volumes]="-v redis:/etc/redis:rw"
+  serviceValues[redis-entrypoint]=$(printf '%s' "--entrypoint=" "[" "\"redis-server\"" "," "\"--requirepass\"" "," "\"${REDIS_PASSWORD}\"" "]")
+  serviceValues[redis-image]="docker.io/redis:6.2-alpine"
+  serviceValues[notification-engine-entrypoint]='--entrypoint ["npm","run","start:notification-engine"]'
+  serviceValues[notification-sender-entrypoint]='--entrypoint ["npm","run","start:notification-sender"]'
+  serviceValues[contextual-scoring-service-entrypoint]='--entrypoint ["npm","run","start:contextual-scoring-service"]'
+  serviceValues[migrations-volumes]="-v uploads:/usr/src/plextrac-api/uploads:rw"
+  serviceValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
+  serviceValues[plextracnginx-ports]="-p 0.0.0.0:80:80 -p 0.0.0.0:443:443"
+  serviceValues[plextracnginx-image]="docker.io/plextrac/plextracnginx:${UPGRADE_STRATEGY:-stable}"
+  
+  title "Starting PlexTrac..."
+  requires_user_plextrac
+  
+  for service in "${serviceNames[@]}"; do
+  debug "Checking $service"
+    local volumes=""
+    local ports=""
+    local healthcheck=""
+    local image="${serviceValues[api-image]}"
+    local restart_policy="--restart=always"
+    local entrypoint=""
+    local deploy=""
+    local env_vars=""
+    if container_client container exists "$service"; then
+      if [ "$(container_client container inspect --format '{{.State.Status}}' "$service")" != "running" ]; then
+        debug "Starting $service"
+        container_client start "$service" 1>/dev/null
+      else
+        debug "$service is already running"
+      fi
+    else
+      if [ "$service" == "plextracdb" ]; then
+        local volumes=${serviceValues[cb-volumes]}
+        local ports="${serviceValues[cb-ports]}"
+        local healthcheck="${serviceValues[cb-healthcheck]}"
+        local image="${serviceValues[cb-image]}"
+      elif [ "$service" == "postgres" ]; then
+        local volumes="${serviceValues[pg-volumes]}"
+        local ports="${serviceValues[pg-ports]}"
+        local healthcheck="${serviceValues[pg-healthcheck]}"
+        local image="${serviceValues[pg-image]}"
+        local env_vars="${serviceValues[pg-env-vars]}"
+      elif [ "$service" == "plextracapi" ]; then
+        local volumes="${serviceValues[api-volumes]}"
+        local healthcheck="${serviceValues[api-healthcheck]}"
+        local image="${serviceValues[api-image]}"
+      elif [ "$service" == "redis" ]; then
+        local volumes="${serviceValues[redis-volumes]}"
+        local image="${serviceValues[redis-image]}"
+        local entrypoint="${serviceValues[redis-entrypoint]}"
+      elif [ "$service" == "notification-engine" ]; then
+        local entrypoint="${serviceValues[notification-engine-entrypoint]}"
+      elif [ "$service" == "notification-sender" ]; then
+        local entrypoint="${serviceValues[notification-sender-entrypoint]}"
+      elif [ "$service" == "contextual-scoring-service" ]; then
+        local entrypoint="${serviceValues[contextual-scoring-service-entrypoint]}"
+        local deploy="" # update this
+      elif [ "$service" == "migrations" ]; then
+        local volumes="${serviceValues[migrations-volumes]}"
+      elif [ "$service" == "plextracnginx" ]; then
+        local volumes="${serviceValues[plextracnginx-volumes]}"
+        local ports="${serviceValues[plextracnginx-ports]}"
+        local image="${serviceValues[plextracnginx-image]}"
+      fi
+      debug "Creating $service"
+      # This specific if loop is because Bash escaping and the specific need for the podman flag --entrypoint were being a massive pain in figuring out. After hours of effort, simply making an if statement here and calling podman directly fixes the escaping issues
+      if [ "$service" == "migrations" ]; then
+        podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:migrate && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no $healthcheck \
+        $volumes --name=${service} $deploy ${serviceValues[network]} $ports -d $image 1>/dev/null
+        continue
+      fi
+      container_client run ${serviceValues[env-file]} $env_vars $entrypoint $restart_policy $healthcheck \
+        $volumes --name=${service} $deploy ${serviceValues[network]} $ports -d $image 1>/dev/null
+    fi
+  done
+  ## TODO: Write bit to edit the resolver as needed / TEST THIS PLEASE
+  waitTimeout=${1:-90}
+  info "Waiting up to ${waitTimeout}s for application startup"
+  local progressBar
+  # todo: extract this to function waitForCondition
+  # it should take an optional param which is a function
+  # that should return 0 when ready
+  (
+    while true; do
+      progressBar=$(printf ".%s" "${progressBar:-}")
+      msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
+      sleep 2
+    done &
+    progressBarPid=$!
+    debug "Waiting for migrations to run and complete if needed"
+    timeout --preserve-status $waitTimeout podman wait migrations >/dev/null || { error "Migrations exceeded timeout"; kill $progressBarPid; exit 1; } &
+
+    timeoutPid=$!
+    trap "kill $progressBarPid $timeoutPid >/dev/null 2>&1 || true" SIGINT SIGTERM
+
+    wait $timeoutPid
+
+    kill $progressBarPid >/dev/null 2>&1 || true
+    >&2 echo -n "${RESET}"
+
+    msg " Done"
+  )
+}

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -216,7 +216,6 @@ function plextrac_start_podman() {
         $volumes --name=${service} $deploy ${serviceValues[network]} $ports -d $image 1>/dev/null
     fi
   done
-  ## TODO: Write bit to edit the resolver as needed / TEST THIS PLEASE
   waitTimeout=${2:-90}
   info "Waiting up to ${waitTimeout}s for application startup"
   local progressBar

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -253,13 +253,10 @@ function podman_pull_images() {
   service_images[plextracnginx-image]="docker.io/plextrac/plextracnginx:${UPGRADE_STRATEGY:-stable}"
 
   info "Pulling updated container images"
-  IMAGE_PRECHECK=true
-  image_version_check
   for image in "${service_images[@]}"; do
     debug "Pulling $image"
     podman pull $image 1>/dev/null
   done
-  image_version_check
   log "Done."
 }
 

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -13,6 +13,8 @@ function podman_setup() {
   pt_volumes["redis"]="${PLEXTRAC_HOME:-.}/volumes/redis"
   pt_volumes["couchbase-backups"]="${PLEXTRAC_BACKUP_PATH}/couchbase"
   pt_volumes["postgres-backups"]="${PLEXTRAC_BACKUP_PATH}/postgres"
+  pt_volumes["nginx_ssl_certs"]="${PLEXTRAC_HOME:-.}/volumes/nginx_ssl_certs"
+  pt_volumes["nginx_logos"]="${PLEXTRAC_HOME:-.}/volumes/nginx_logos"
   for volume in "${!pt_volumes[@]}"; do
     if container_client volume exists "$volume"; then
       debug "-- Volume $volume already exists"

--- a/src/_reload_cert.sh
+++ b/src/_reload_cert.sh
@@ -1,6 +1,12 @@
 # Build functionality for certificate renewal / injection into NGINX
 
 function mod_reload-cert() {
+  declare -A nginxValues
+  nginxValues[env-file]="--env-file /opt/plextrac/.env"
+  nginxValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
+  nginxValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
+  nginxValues[plextracnginx-image]="docker.io/plextrac/plextracnginx:${UPGRADE_STRATEGY:-stable}"
+
   title "PlexTrac SSL Certificate Renewal"
   # Check if using LETS_ENCRYPT
   LETS_ENCRYPT_EMAIL=${LETS_ENCRYPT_EMAIL:-}
@@ -12,7 +18,13 @@ function mod_reload-cert() {
     info "Would you like to reload the SSL Certificates? This will recreate the NGINX container"
     if get_user_approval; then
       info "Recreating plextrac-plextracnginx-1"
-      compose_client up -d --force-recreate plextracnginx
+      if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+        podman rm -f plextracnginx; podman volume rm letsencrypt
+        podman run ${nginxValues[env-file]} --restart=always \
+        ${nginxValues[plextracnginx-volumes]} --name=plextracnginx --network=plextrac ${nginxValues[plextracnginx-ports]} -d ${nginxValues[plextracnginx-image]} 1>/dev/null
+      else
+        compose_client up -d --force-recreate plextracnginx
+      fi
     else 
       die "No changes made!"
     fi
@@ -23,7 +35,13 @@ function mod_reload-cert() {
     info "Would you like to reload your custom or self-signed SSL certificates? This will recreate the NGINX container"
     if get_user_approval; then
       info "Reloading certificates..."
-      compose_client up -d --force-recreate plextracnginx
+      if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+        podman rm -f plextracnginx; podman volume rm letsencrypt
+        podman run ${nginxValues[env-file]} --restart=always \
+        ${nginxValues[plextracnginx-volumes]} --name=plextracnginx --network=plextrac ${nginxValues[plextracnginx-ports]} -d ${nginxValues[plextracnginx-image]} 1>/dev/null
+      else
+        compose_client up -d --force-recreate plextracnginx
+      fi
     else
       die "No changes made!"
     fi

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -24,8 +24,14 @@ function restore_doUploadsRestore() {
 
   if get_user_approval; then
     log "Restoring from $latestBackup"
-    debug "`cat $latestBackup | compose_client run --workdir /usr/src/plextrac-api --rm --entrypoint='' -T \
+    local cmd='compose_client -T'
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      local cmd='podman'
+      cat $latestBackup | podman cp - plextracapi:/usr/src/plextrac-api
+    else
+      debug "`cat $latestBackup | $cmd run --workdir /usr/src/plextrac-api --rm --entrypoint='' \
       $coreBackendComposeService tar -xzf -`"
+    fi
     log "Done"
   fi
 }
@@ -33,8 +39,10 @@ function restore_doUploadsRestore() {
 function restore_doCouchbaseRestore() {
   title "Restoring Couchbase from backup"
   debug "Fixing permissions"
-  debug "`compose_client exec -T $couchbaseComposeService \
-    chown -R 1337:1337 /backups 2>&1`"
+  if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+    debug "`compose_client exec -T $couchbaseComposeService \
+      chown -R 1337:1337 /backups 2>&1`"
+  fi
   latestBackup="`ls -dc1 ${PLEXTRAC_BACKUP_PATH}/couchbase/* | head -n1`"
   backupFile=`basename $latestBackup`
   info "Latest backup: $latestBackup"
@@ -45,19 +53,32 @@ function restore_doCouchbaseRestore() {
   if get_user_approval; then
     log "Restoring from $backupFile"
     log "Extracting backup files"
-    debug "`compose_client exec -T --user 1337 --workdir /backups $couchbaseComposeService \
-      tar -xzvf /backups/$backupFile 2>&1`"
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      podman exec --workdir /backups $couchbaseComposeService tar -xzvf /backups/$backupFile
+    else
+      debug "`compose_client exec -T --user 1337 --workdir /backups $couchbaseComposeService \
+        tar -xzvf /backups/$backupFile 2>&1`"
+    fi
 
     log "Running database restore"
-    # We have the TTY enabled by default so the output from cbrestore is intelligible
-    tty -s || { debug "Disabling TTY allocation for Couchbase restore due to non-interactive invocation"; ttyFlag="-T"; }
-    compose_client exec ${ttyFlag:-} $couchbaseComposeService cbrestore /backups http://127.0.0.1:8091 \
-      -u ${CB_BACKUP_USER} -p "${CB_BACKUP_PASS}" --from-date 2022-01-01 -x conflict_resolve=0,data_only=1
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      podman exec $couchbaseComposeService cbrestore /backups http://127.0.0.1:8091 \
+        -u ${CB_BACKUP_USER} -p "${CB_BACKUP_PASS}" --from-date 2022-01-01 -x conflict_resolve=0,data_only=1
+    else
+      # We have the TTY enabled by default so the output from cbrestore is intelligible
+      tty -s || { debug "Disabling TTY allocation for Couchbase restore due to non-interactive invocation"; ttyFlag="-T"; }
+      compose_client exec ${ttyFlag:-} $couchbaseComposeService cbrestore /backups http://127.0.0.1:8091 \
+        -u ${CB_BACKUP_USER} -p "${CB_BACKUP_PASS}" --from-date 2022-01-01 -x conflict_resolve=0,data_only=1
+    fi
 
     log "Cleaning up extracted backup files"
     dirName=`basename -s .tar.gz $backupFile`
-    debug "`compose_client exec -T --user 1337 --workdir /backups $couchbaseComposeService \
-      rm -rf /backups/$dirName 2>&1`"
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      podman exec --workdir /backups $couchbaseComposeService rm -rf /backups/$dirName
+    else
+      debug "`compose_client exec -T --user 1337 --workdir /backups $couchbaseComposeService \
+        rm -rf /backups/$dirName 2>&1`"
+    fi
     log "Done"
   fi
 }
@@ -75,19 +96,27 @@ function restore_doPostgresRestore() {
     databaseBackups=$(basename -s .psql `tar -tf $latestBackup | awk '/.psql/{print $1}'`)
     log "Restoring from $backupFile"
     log "Databases to restore:\n$databaseBackups"
-      debug "`compose_client exec -T --user 1337 $postgresComposeService\
+    local cmd='compose_client exec -T --user 1337'
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      local cmd='podman exec'
+    fi
+      debug "`$cmd $postgresComposeService \
         tar -tf /backups/$backupFile 2>&1`"
+    local cmd='compose_client exec -T'
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      local cmd='podman exec'
+    fi
     for db in $databaseBackups; do
       log "Extracting backup for $db"
-      debug "`compose_client exec -T $postgresComposeService\
+      debug "`$cmd $postgresComposeService\
         tar -xvzf /backups/$backupFile ./$db.psql 2>&1`"
       dbAdminEnvvar="PG_${db^^}_ADMIN_USER"
       dbAdminRole=$(eval echo "\$$dbAdminEnvvar")
       log "Restoring $db with role:${dbAdminRole}"
       dbRestoreFlags="-d $db --clean --if-exists --no-privileges --no-owner --role=$dbAdminRole  --disable-triggers --verbose"
-      debug "`compose_client exec -T -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
+      debug "`$cmd -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
         pg_restore -U $POSTGRES_USER $dbRestoreFlags ./$db.psql 2>&1`"
-      debug "`compose_client exec -T $postgresComposeService \
+      debug "`$cmd $postgresComposeService \
         rm ./$db.psql 2>&1`"
     done
   fi

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -24,12 +24,10 @@ function restore_doUploadsRestore() {
 
   if get_user_approval; then
     log "Restoring from $latestBackup"
-    local cmd='compose_client -T'
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-      local cmd='podman'
       cat $latestBackup | podman cp - plextracapi:/usr/src/plextrac-api
     else
-      debug "`cat $latestBackup | $cmd run --workdir /usr/src/plextrac-api --rm --entrypoint='' \
+      debug "`cat $latestBackup | compose_client run -T --workdir /usr/src/plextrac-api --rm --entrypoint='' \
       $coreBackendComposeService tar -xzf -`"
     fi
     log "Done"

--- a/src/_setup_packages.sh
+++ b/src/_setup_packages.sh
@@ -19,11 +19,13 @@ function system_packages__do_system_upgrade() {
   info "Updating OS packages, this make take some time!"
   nobest="--nobest"
   os_check
-  if echo "$OS_NAME" | grep -q 'CentOS'; then
+  if grep -q 'CentOS' <(echo "$OS_NAME"); then
     nobest=""
-  elif echo "$OS_NAME"  | grep -q 'Hat'; then
-    if echo "$OS_VERSION" | grep -v '7'; then
-      nobest="--nobest"
+  elif grep -q 'Hat' <(echo "$OS_NAME"); then
+    if grep -vq '7.' <(echo "$OS_VERSION"); then
+      if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+        nobest="--nobest"
+      fi
     else
       nobest=""
     fi
@@ -37,7 +39,7 @@ function system_packages__do_system_upgrade() {
       debug "$out"
       ;;
     "yum")
-      out=`yum upgrade -q -y $nobest 2>&1` || { error "Failed to upgrade system packages"; debug "$out"; return 1; }
+      out=`yum upgrade -y $nobest 2>&1` || { error "Failed to upgrade system packages"; debug "$out"; return 1; }
       debug "$out"
       ;;
     *)  
@@ -105,7 +107,7 @@ function install_docker() {
         info "installing docker, this might take some time..."
         _system_cmd_with_debug_and_fail "yum install -q -y yum-utils"
         # RHEL Docker repo has been deprecated, so only CentOS repo is used
-          _system_cmd_with_debug_and_fail "yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo"
+        _system_cmd_with_debug_and_fail "yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo"
         system_packages__refresh_package_lists
         _system_cmd_with_debug_and_fail "yum install -q -y docker-ce docker-ce-cli containerd.io docker-compose-plugin 2>&1"
         _system_cmd_with_debug_and_fail "systemctl enable docker 2>&1"
@@ -159,4 +161,74 @@ function _system_cmd_with_debug_and_fail() {
   fail_msg=${2:-"Command failed: '$cmd'"}
   out=`eval $cmd` || { error "$fail_msg"; debug "$out"; return 1; }
   debug "$out"
+}
+
+function install_podman() {
+  if ! command -v podman &> /dev/null || [ "${1:-}" == "force" ]; then
+    case `systemPackageManager` in
+      "yum")
+        info "installing podman, this might take some time..."
+        if grep -q "Red Hat" <(echo "$OS_NAME"); then
+          if grep -q "8." <(echo "$OS_VERSION"); then
+            _system_cmd_with_debug_and_fail "yum module enable -y container-tools:rhel8"
+          elif grep -q "9." <(echo "$OS_VERSION"); then
+            _system_cmd_with_debug_and_fail "yum install -y container-tools"
+          fi
+        fi
+        _system_cmd_with_debug_and_fail "yum install -q -y podman podman-plugins"
+        event__log_activity "install:podman" $(podman --version)
+        ;;
+      *)
+        error "unsupported"
+        exit 1
+        ;;
+    esac
+    touch /etc/containers/nodocker
+    log "Done."
+  else
+    info "podman already installed, version: $(podman --version | grep -o -E '.\..\..')"
+  fi
+}
+
+function install_podman_compose() {
+  if ! command -v podman-compose &> /dev/null || [ "${1:-}" == "force" ]; then
+    case `systemPackageManager` in
+      "yum")
+        info "installing podman-compose, this might take some time..."
+        os_check
+        # If its RHEL
+        if echo "$OS_NAME" | grep -q "Red"; then
+          arch="$(arch)"
+          debug "$arch"
+          os_ver=$(echo "$OS_VERSION" | cut -d '.' -f1)
+          debug "$os_ver"
+            _system_cmd_with_debug_and_fail "subscription-manager repos --enable codeready-builder-for-rhel-$os_ver-$arch-rpms"
+            _system_cmd_with_debug_and_fail "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$os_ver.noarch.rpm"
+        fi
+
+        # If its CentOS or Rocky Linux
+        if echo "$OS_NAME" | grep -q "CentOS" || echo "$OS_NAME" | grep -q "Rocky"; then
+          if echo "$OS_VERSION" | grep -q "9."; then
+            _system_cmd_with_debug_and_fail "yum config-manager --set-enabled crb 2>&1"
+          elif echo "$OS_VERSION" | grep -q "8."; then
+            _system_cmd_with_debug_and_fail "yum config-manager --set-enabled powertools 2>&1"
+          fi
+        fi
+        if echo "$OS_NAME" | grep -q "CentOS"; then
+          _system_cmd_with_debug_and_fail "yum install -y epel-release epel-next-release 2>&1"
+        elif echo "$OS_NAME" | grep -q "Rocky"; then
+          _system_cmd_with_debug_and_fail "yum install -y epel-release 2>&1"
+        fi
+        _system_cmd_with_debug_and_fail "yum install -q -y podman-compose 2>&1"
+        event__log_activity "install:podman-compose" $(podman-compose --version 2>1)
+        ;;
+      *)
+        error "unsupported"
+        exit 1
+        ;;
+    esac
+    log "Done."
+  else
+    info "podman-compose already installed, version: $(podman-compose --version 2>1 | grep compose | grep -o -E '.\..\..')"
+  fi
 }

--- a/src/_stop.sh
+++ b/src/_stop.sh
@@ -5,14 +5,31 @@
 
 function mod_stop() {
   title "Attempting to gracefully stop PlexTrac..."
-  debug "Stopping API, NGINX, Notification engine/sender"
-  compose_client stop plextracapi plextracnginx notification-engine notification-sender
+  debug "Stopping API Services..."
+  for service in $(docker ps --format '{{.Names}}' | grep -E 'plextracapi|plextracnginx|notification-engine|notification-sender|contextual-scoring-service'); do
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      container_client stop $service
+    else
+      compose_client stop $service
+    fi
+  done
   sleep 2
+  debug "Done."
   debug "Stopping Couchbase, Postres, and Redis"
-  compose_client stop redis plextracdb postgres
+  for service in $(docker ps --format '{{.Names}}' | grep -E 'couchbase|postgres|redis'); do
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      container_client stop $service
+    else
+      compose_client stop $service
+    fi
+  done
   sleep 2
   debug "Ensuring all services are stopped"
-  compose_client stop
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    docker stop -a
+  else
+    compose_client stop
+  fi
   info "-----"
   info "PlexTrac stopped. It's now safe to update and restart"
 }

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -59,7 +59,7 @@ function mod_update() {
                   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
                     unhealthy_services=$(for service in $(podman ps -a --format json | jq -r .[].Names | grep '"' | cut -d '"' -f2); do podman inspect $service --format json | jq -r '.[] | select(.State.Health.Status == "unhealthy" or (.State.Status != "running" and .State.ExitCode != 0) or .State.Status == "created") | .Name' | xargs -r printf "%s;"; done)
                   else
-                    unhealthy_services=$(compose_client ps -a --format json | jq -r '. | select(.Health == "unhealthy" or (.State != "running" and .ExitCode != 0) or .State == "created" not (has("migrations")) | .Service' | xargs -r printf "%s;")
+                    unhealthy_services=$(compose_client ps -a --format json | jq -r '. | select(.Health == "unhealthy" or (.State != "running" and .ExitCode != 0) or .State == "created" ) | .Service' | xargs -r printf "%s;")
                   fi
                   if [[ "${unhealthy_services}" == "" ]]; then break; fi
                   info "Detected unhealthy services: ${unhealthy_services}"

--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -25,7 +25,11 @@ function version_check() {
   ## LOGIC: RunVer
   debug "Running Version"
   # Get running version of Backend
-  running_backend_version="$(for i in $(docker compose ps plextracapi -q); do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    running_backend_version="$(for i in $(podman ps -a -q --filter name=plextracapi); do podman inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
+  else
+    running_backend_version="$(for i in $(compose_client ps plextracapi -q); do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
+  fi
 
   # CONDITION: plextracapi IS/NOT RUNNING
   # Validate that the app is running and returning a version

--- a/src/plextrac
+++ b/src/plextrac
@@ -108,7 +108,8 @@ function mod_help() {
   info "Examples:\n"
   info "PlexTrac Setup:"
   log "Prepare server for PlexTrac:         ${DIM}${GREEN}sudo ./plextrac initialize${RESET}"
-  log "Migrate existing instance:           ${DIM}${GREEN}plextrac migrate && plextrac install -y${RESET}"
+  #Deprecated Migrate Command
+  #log "Migrate existing instance:           ${DIM}${GREEN}plextrac migrate && plextrac install -y${RESET}"
   log "Install new instance:                ${DIM}${GREEN}plextrac install -y${RESET}"
   log ""
   info "PlexTrac Management:\n"
@@ -121,6 +122,7 @@ function mod_help() {
   log "check                                ${DIM}checks for version & status of PlexTrac application${RESET}"
   log "clean                                ${DIM}archives (compresses) local backups and removes stale copies${RESET}"
   log "configure                            ${DIM}does initial configuration required for PlexTrac application${RESET}"
+  log "autocomplete                         ${DIM}creates CLI tab completion for plextrac utility commands${RESET}"
   log "initialize                           ${DIM}initialize local system for PlexTrac installation${RESET}"
   log "info                                 ${DIM}display information about the current PlexTrac Instance${RESET}"
   log "install                              ${DIM}install PlexTrac (assumes previously initialized system)${RESET}"

--- a/src/plextrac
+++ b/src/plextrac
@@ -4,6 +4,41 @@ set -Eeuo pipefail
 VERSION=0.6.0
 
 
+## Podman Global Declaration Variable
+declare -A svcValues
+
+export POSTGRES_HOST_AUTH_METHOD=scram-sha-256
+export POSTGRES_INITDB_ARGS="--auth-local=scram-sha-256 --auth-host=scram-sha-256"
+export PG_MIGRATE_PATH=/usr/src/plextrac-api
+export PGDATA=/var/lib/postgresql/data/pgdata
+
+databaseNames=("plextracdb" "postgres")
+serviceNames=("plextracdb" "postgres" "redis" "plextracapi" "notification-engine" "notification-sender" "contextual-scoring-service" "migrations" "plextracnginx")
+svcValues[network]="--network=plextrac"
+svcValues[env-file]="--env-file /opt/plextrac/.env"
+svcValues[cb-volumes]="-v dbdata:/opt/couchbase/var:Z,U -v couchbase-backups:/backups:Z,U"
+svcValues[cb-ports]="-p 127.0.0.1:8091-8094:8091-8094"
+svcValues[cb-image]="docker.io/plextrac/plextracdb:7.2.0"
+svcValues[pg-volumes]="-v postgres-initdb:/docker-entrypoint-initdb.d:Z,U -v postgres-data:/var/lib/postgresql/data -v postgres-backups:/backups:Z,U"
+svcValues[pg-ports]="-p 127.0.0.1::5432"
+svcValues[pg-healthcheck]='--health-cmd=["pg_isready","-U","postgres"]'
+svcValues[pg-image]="docker.io/postgres:14-alpine"
+svcValues[pg-env-vars]="-e 'POSTGRES_HOST_AUTH_METHOD' -e 'POSTGRES_INITDB_ARGS' -e 'PG_MIGRATE_PATH' -e 'PGDATA'"
+svcValues[api-volumes]="-v uploads:/usr/src/plextrac-api/uploads:Z,U -v datalake-maintainer-keys:/usr/src/plextrac-api/keys/gcp -v localesOverride:/usr/src/plextrac-api/localesOverride:rw"
+svcValues[api-healthcheck]='--health-cmd=["wget","-q","-O-","http://127.0.0.1:4350/api/v2/health/live"]'
+svcValues[redis-volumes]="-v redis:/etc/redis:rw"
+svcValues[redis-image]="docker.io/redis:6.2-alpine"
+svcValues[notification-engine-entrypoint]='--entrypoint ["npm","run","start:notification-engine"]'
+svcValues[notification-engine-healthcheck]='--health-cmd=["npm","run","healthcheck:notification-engine","readiness","10","--","--no-update-notifier"]'
+svcValues[notification-sender-entrypoint]='--entrypoint ["npm","run","start:notification-sender"]'
+svcValues[notification-sender-healthcheck]='--health-cmd=["npm","run","healthcheck:notification-sender","readiness","10","--","--no-update-notifier"]'
+svcValues[contextual-scoring-service-entrypoint]='--entrypoint ["npm","run","start:contextual-scoring-service"]'
+svcValues[contextual-scoring-service-healthcheck]='--health-cmd=["npm","run","healthcheck:contextual-scoring-service","liveness","10","--","--no-update-notifier"]'
+svcValues[migrations-volumes]="-v uploads:/usr/src/plextrac-api/uploads:rw"
+svcValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
+svcValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
+svcValues[plextracnginx-healthcheck]='--health-cmd=["echo","GET","/","|","openssl","s_client","-quiet","-connect","127.0.0.1:443"]'
+
 trap 'cleanup $?' SIGINT ERR EXIT
 
 function backtrace() {
@@ -309,7 +344,7 @@ function mod_install() {
     log "Please see the config steps at"
     log "https://docs.plextrac.com/plextrac-documentation/product-documentation-1/on-premise-management/setting-up-historical-logs"
   else
-    plextrac_install_podman
+    plextrac_install_podman "svcValues"
   fi
 }
 
@@ -331,7 +366,7 @@ function mod_configure() {
 
 function mod_start() {
   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-    plextrac_start_podman
+    plextrac_start_podman "svcValues"
   else
     title "Starting PlexTrac..."
     requires_user_plextrac

--- a/src/plextrac
+++ b/src/plextrac
@@ -42,7 +42,7 @@ svcValues[contextual-scoring-service-healthcheck]='--health-cmd=["npm","run","he
 #Migrations
 svcValues[migrations-volumes]="--volumes-from=plextracapi"
 #Nginx
-svcValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
+svcValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw -v nginx_ssl_certs:/etc/ssl/:Z,U -v nginx_logos:/usr/share/nginx/html/dist/img/:Z,U"
 svcValues[plextracnginx-healthcheck]='--health-cmd=["echo","GET","/","|","openssl","s_client","-quiet","-connect","127.0.0.1:443"]'
 
 trap 'cleanup $?' SIGINT ERR EXIT

--- a/src/plextrac
+++ b/src/plextrac
@@ -7,34 +7,41 @@ VERSION=0.6.0
 ## Podman Global Declaration Variable
 declare -A svcValues
 
-export POSTGRES_HOST_AUTH_METHOD=scram-sha-256
-export POSTGRES_INITDB_ARGS="--auth-local=scram-sha-256 --auth-host=scram-sha-256"
-export PG_MIGRATE_PATH=/usr/src/plextrac-api
-export PGDATA=/var/lib/postgresql/data/pgdata
+export POSTGRES_INITDB_ARGS='--auth-local=scram-sha-256 --auth-host=scram-sha-256'
 
 databaseNames=("plextracdb" "postgres")
 serviceNames=("plextracdb" "postgres" "redis" "plextracapi" "notification-engine" "notification-sender" "contextual-scoring-service" "migrations" "plextracnginx")
+#Defaults
 svcValues[network]="--network=plextrac"
 svcValues[env-file]="--env-file /opt/plextrac/.env"
+#Couchbase
 svcValues[cb-volumes]="-v dbdata:/opt/couchbase/var:Z,U -v couchbase-backups:/backups:Z,U"
 svcValues[cb-ports]="-p 127.0.0.1:8091-8094:8091-8094"
 svcValues[cb-image]="docker.io/plextrac/plextracdb:7.2.0"
-svcValues[pg-volumes]="-v postgres-initdb:/docker-entrypoint-initdb.d:Z,U -v postgres-data:/var/lib/postgresql/data -v postgres-backups:/backups:Z,U"
+#Postgres
+svcValues[pg-volumes]="-v postgres-initdb:/docker-entrypoint-initdb.d -v postgres-data:/var/lib/postgresql/data -v postgres-backups:/backups:Z"
 svcValues[pg-ports]="-p 127.0.0.1::5432"
-svcValues[pg-healthcheck]='--health-cmd=["pg_isready","-U","postgres"]'
+svcValues[pg-healthcheck]='--health-cmd=["pg_isready","-U","internalonly"]'
 svcValues[pg-image]="docker.io/postgres:14-alpine"
-svcValues[pg-env-vars]="-e 'POSTGRES_HOST_AUTH_METHOD' -e 'POSTGRES_INITDB_ARGS' -e 'PG_MIGRATE_PATH' -e 'PGDATA'"
-svcValues[api-volumes]="-v uploads:/usr/src/plextrac-api/uploads:Z,U -v datalake-maintainer-keys:/usr/src/plextrac-api/keys/gcp -v localesOverride:/usr/src/plextrac-api/localesOverride:rw"
+svcValues[pg-env-vars]="-e 'POSTGRES_HOST_AUTH_METHOD=scram-sha-256' -e 'PG_MIGRATE_PATH=/usr/src/plextrac-api' -e 'PGDATA=/var/lib/postgresql/data/pgdata'"
+#API
+svcValues[api-volumes]="-v uploads:/usr/src/plextrac-api/uploads:Z,U -v localesOverride:/usr/src/plextrac-api/localesOverride:rw"
 svcValues[api-healthcheck]='--health-cmd=["wget","-q","-O-","http://127.0.0.1:4350/api/v2/health/live"]'
+#Redis
 svcValues[redis-volumes]="-v redis:/etc/redis:rw"
 svcValues[redis-image]="docker.io/redis:6.2-alpine"
+svcValues[redis-healthcheck]='--health-cmd=["redis-cli","--raw","incr","ping"]'
+#Notification engine/sender
 svcValues[notification-engine-entrypoint]='--entrypoint ["npm","run","start:notification-engine"]'
 svcValues[notification-engine-healthcheck]='--health-cmd=["npm","run","healthcheck:notification-engine","readiness","10","--","--no-update-notifier"]'
 svcValues[notification-sender-entrypoint]='--entrypoint ["npm","run","start:notification-sender"]'
 svcValues[notification-sender-healthcheck]='--health-cmd=["npm","run","healthcheck:notification-sender","readiness","10","--","--no-update-notifier"]'
+#Contextual scoring service
 svcValues[contextual-scoring-service-entrypoint]='--entrypoint ["npm","run","start:contextual-scoring-service"]'
 svcValues[contextual-scoring-service-healthcheck]='--health-cmd=["npm","run","healthcheck:contextual-scoring-service","liveness","10","--","--no-update-notifier"]'
-svcValues[migrations-volumes]="-v uploads:/usr/src/plextrac-api/uploads:rw"
+#Migrations
+svcValues[migrations-volumes]="--volumes-from=plextracapi"
+#Nginx
 svcValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
 svcValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
 svcValues[plextracnginx-healthcheck]='--health-cmd=["echo","GET","/","|","openssl","s_client","-quiet","-connect","127.0.0.1:443"]'
@@ -361,7 +368,9 @@ function mod_configure() {
     deploy_volume_contents_postgres
   elif [ "$CONTAINER_RUNTIME" == "podman" ]; then
     podman_setup
+    deploy_volume_contents_postgres
   fi
+  mod_autocomplete
 }
 
 function mod_start() {

--- a/src/plextrac
+++ b/src/plextrac
@@ -43,7 +43,6 @@ svcValues[contextual-scoring-service-healthcheck]='--health-cmd=["npm","run","he
 svcValues[migrations-volumes]="--volumes-from=plextracapi"
 #Nginx
 svcValues[plextracnginx-volumes]="-v letsencrypt:/etc/letsencrypt:rw"
-svcValues[plextracnginx-ports]="-p 0.0.0.0:443:443"
 svcValues[plextracnginx-healthcheck]='--health-cmd=["echo","GET","/","|","openssl","s_client","-quiet","-connect","127.0.0.1:443"]'
 
 trap 'cleanup $?' SIGINT ERR EXIT

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.5.5
+VERSION=0.6.0
 
 trap 'cleanup $?' SIGINT ERR EXIT
 
@@ -175,6 +175,11 @@ function main() {
         shift
         shift
         ;;
+      "-c" | "--container-runtime")
+        CONTAINER_RUNTIME=$2
+        shift
+        shift
+        ;;
       *)
         if declare -f mod_$1 >/dev/null 2>&1; then
           # enable event logging for sub commands
@@ -189,6 +194,7 @@ function main() {
     esac
   done
   export PLEXTRAC_HOME=${PLEXTRAC_HOME:-/opt/plextrac}
+  export CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"}
   _load_env
   _load_static
   interactiveHeader
@@ -241,12 +247,21 @@ function mod_dist() {
 
 function mod_initialize() {
   info "Initializing environment for PlexTrac..."
+  check_container_runtime
   requires_user_root
   info "Setting up system packages"
   system_packages__do_system_upgrade
   system_packages__install_system_dependencies
-  install_docker "${FORCEUPGRADE-}"
-  install_docker_compose "${FORCEUPGRADE-}"
+  if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+    install_docker "${FORCEUPGRADE-}"
+    install_docker_compose "${FORCEUPGRADE-}"
+  fi
+  if [ "$CONTAINER_RUNTIME" == "podman" ] || [ "$CONTAINER_RUNTIME" == "podman-compose" ]; then
+    install_podman "${FORCEUPGRADE-}"
+    if [ "$CONTAINER_RUNTIME" == "podman-compose" ]; then
+      install_podman_compose "${FORCEUPGRADE-}"
+    fi
+  fi
   title "Setting up local PlexTrac user"
   create_user
   configure_user_environment
@@ -255,88 +270,101 @@ function mod_initialize() {
 }
 
 function mod_install() {
-  title "Installing PlexTrac Instance"
-  requires_user_plextrac
-  mod_configure
-  info "Starting Databases before other services"
-  compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
-  info "Sleeping to give Databases a chance to start up"
-  local progressBar
-  for i in `seq 1 20`; do
-    progressBar=`printf ".%.0s%s"  {1..$i} "${progressBar:-}"`
-    msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
-    sleep 2
-  done
-  >&2 echo -n "${RESET}"
-  log "Done"
-  mod_autofix
-  if [ ${RESTOREONINSTALL:-0} -eq 1 ]; then
-    info "Restoring from backups"
-    log "Restoring databases first"
-    RESTORETARGET="couchbase" mod_restore
-    if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/postgres/)" ]; then
-      RESTORETARGET="postgres" mod_restore
+  if [ "$CONTAINER_RUNTIME" != "podman" ]; then
+    title "Installing PlexTrac Instance"
+    requires_user_plextrac
+    mod_configure
+    info "Starting Databases before other services"
+    compose_client up -d "$couchbaseComposeService" "$postgresComposeService"
+    info "Sleeping to give Databases a chance to start up"
+    local progressBar
+    for i in `seq 1 20`; do
+      progressBar=`printf ".%.0s%s"  {1..$i} "${progressBar:-}"`
+      msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
+      sleep 2
+    done
+    >&2 echo -n "${RESET}"
+    log "Done"
+    mod_autofix
+    if [ ${RESTOREONINSTALL:-0} -eq 1 ]; then
+      info "Restoring from backups"
+      log "Restoring databases first"
+      RESTORETARGET="couchbase" mod_restore
+      if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/postgres/)" ]; then
+        RESTORETARGET="postgres" mod_restore
+      fi
+      if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/uploads/)" ]; then
+        log "Starting API to prepare for uploads restore"
+        compose_client up -d "$coreBackendComposeService"
+        log "Restoring uploads"
+        RESTORETARGET="uploads" mod_restore
+      fi
     fi
-    if [ -n "$(ls -A -- ${PLEXTRAC_BACKUP_PATH}/uploads/)" ]; then
-      log "Starting API to prepare for uploads restore"
-      compose_client up -d "$coreBackendComposeService"
-      log "Restoring uploads"
-      RESTORETARGET="uploads" mod_restore
-    fi
+    pull_docker_images
+    mod_start "${INSTALL_WAIT_TIMEOUT:-600}" # allow up to 10 or specified minutes for startup on install, due to migrations
+    mod_info
+    info "Post installation note:"
+    log "If you wish to have access to historical logs, you can configure docker to send logs to journald."
+    log "Please see the config steps at"
+    log "https://docs.plextrac.com/plextrac-documentation/product-documentation-1/on-premise-management/setting-up-historical-logs"
+  else
+    plextrac_install_podman
   fi
-  pull_docker_images
-  mod_start "${INSTALL_WAIT_TIMEOUT:-600}" # allow up to 10 or specified minutes for startup on install, due to migrations
-  mod_info
-  info "Post installation note:"
-  log "If you wish to have access to historical logs, you can configure docker to send logs to journald."
-  log "Please see the config steps at"
-  log "https://docs.plextrac.com/plextrac-documentation/product-documentation-1/on-premise-management/setting-up-historical-logs"
 }
 
 function mod_configure() {
   title "Setting up base PlexTrac configuration..."
   requires_user_plextrac
+  check_container_runtime
   generate_default_config
   login_dockerhub
-  updateComposeConfig
-  validateComposeConfig
-  create_volume_directories
-  deploy_volume_contents_postgres
+  if [ "$CONTAINER_RUNTIME" == "docker" ] || [ "$CONTAINER_RUNTIME" == "podman-compose" ]; then
+    updateComposeConfig
+    validateComposeConfig
+    create_volume_directories
+    deploy_volume_contents_postgres
+  elif [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    podman_setup
+  fi
 }
 
 function mod_start() {
-  title "Starting PlexTrac..."
-  requires_user_plextrac
-  # Enable database migrations on startup
-  compose_client --profile=database-migrations up -d --remove-orphans
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    plextrac_start_podman
+  else
+    title "Starting PlexTrac..."
+    requires_user_plextrac
+    # Enable database migrations on startup
+    compose_client --profile=database-migrations up -d --remove-orphans
 
-  waitTimeout=${1:-90}
-  info "Waiting up to ${waitTimeout}s for application startup"
-  local progressBar
-  # todo: extract this to function waitForCondition
-  # it should take an optional param which is a function
-  # that should return 0 when ready
-  (
-    while true; do
-      progressBar=$(printf ".%s" "${progressBar:-}")
-      msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
-      sleep 2
-    done &
-    progressBarPid=$!
-    timeout --preserve-status $waitTimeout docker wait \
-      "$(compose_client ps couchbase-migrations -q)" >/dev/null \
-      || { error "Migrations exceeded timeout"; kill $progressBarPid; exit 1; } &
+    waitTimeout=${1:-90}
+    info "Waiting up to ${waitTimeout}s for application startup"
+    local progressBar
+    # todo: extract this to function waitForCondition
+    # it should take an optional param which is a function
+    # that should return 0 when ready
+    (
+      while true; do
+        progressBar=$(printf ".%s" "${progressBar:-}")
+        msg "\r%b" "${GREEN}[+]${RESET} ${NOCURSOR}${progressBar}"
+        sleep 2
+      done &
+      progressBarPid=$!
+      timeout --preserve-status $waitTimeout docker wait \
+        "$(compose_client ps couchbase-migrations -q)" >/dev/null \
+        || { error "Migrations exceeded timeout"; kill $progressBarPid; exit 1; } &
 
-    timeoutPid=$!
-    trap "kill $progressBarPid $timeoutPid >/dev/null 2>&1 || true" SIGINT SIGTERM
+      timeoutPid=$!
+      trap "kill $progressBarPid $timeoutPid >/dev/null 2>&1 || true" SIGINT SIGTERM
 
-    wait $timeoutPid
+      wait $timeoutPid
 
-    kill $progressBarPid >/dev/null 2>&1 || true
-    >&2 echo -n "${RESET}"
+      kill $progressBarPid >/dev/null 2>&1 || true
+      >&2 echo -n "${RESET}"
 
-    msg " Done"
-  )
+      msg " Done"
+    )
+  fi
 }
 
 function mod_autofix() {

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -240,6 +240,15 @@ services:
     volumes:
     - redis:/etc/redis:rw
     restart: always
+    healthcheck:
+      test:
+      - "CMD"
+      - "redis-cli"
+      - "--raw"
+      - "incr"
+      - "ping"
+      interval: 10s
+      timeout: 30s
 
   postgres:
     image: postgres:14-alpine
@@ -279,7 +288,7 @@ services:
     - 127.0.0.1:5432:5432/tcp
     restart: always
     healthcheck: # Define healthcheck to be able to use the `service_healthy` condition.
-      test: pg_isready -U postgres
+      test: pg_isready -U ${POSTGRES_USER:-internalonly}
       interval: 10s
       timeout: 30s
       retries: 5


### PR DESCRIPTION
## Description

There are several good reasons to support podman as a container runtime. There have been some security concerns around using Docker in the RHEL distribution and the goal of this upgrade is to support `podman` and eventually, podman-compose.

## Tasks
- [x] Initial buildout to support Podman in RHEL
- [x] Build out install and init functions to support Podman
- [x] Build out support for all command natively with Podman
- [x] Investigate behavior on reboot (resilience)
- [x] QA full suite Testing
- [x] DR full testing                                                               

**Disclaimer:** Tests are were run from blank VMs in Google Cloud ComputeEngine with the provided Cloud Images for the above distributions. Testing was done exclusively on RHEL 9 in rootless mode using Systemd. This is preferred according to RedHat since Podman 5 removes support for CNI networking.

## Notes
The implementation of podman comes with some trade-offs:

- Restarting the host VM will not start the application containers backup. This is due to how podman implements rootless containers and offers systemd unit files as a solution. If this is desired, then user are encouraged to follow this or a similar method to create those systemd unit files and configuration. However, PlexTrac doesn't officially support this and isn't responsible for any side-effects of using this method including data loss. The officially supported method is to run `plextrac start` if the host VM every restarts
- Due to podman using rootless containers and the way in which it does that, using `su` or similar command to switch users followed by interacting with the manager util will break the containers due to how the permissions work. RedHat states that a direct ssh session to the user you want to or are running podman containers as, is the recommended path. There may be work arounds for this including `loginctl enable-linger plextrac` depending on your operating environment.
- RedHat's RHEL 9 uses SELinux enforced which may cause issues depending on the security posture of the host OS. On a base install of RHEL 9 from a cloud provider there is a need to allow binding to port 443 via a `/etc/sysctl.conf` change
  - Add the following to the `/etc/sysctl.conf` file: `net.ipv4.ip_unprivileged_port_start=443`
  - Reload sysctl: `sysctl --system`

## Change Log
- Added environment variable container runtime evaluation on init and configure
- Added functionality for installing `podman` and `podman-plugins` from the native RHEL repos
- Added sub-functionality to `plextrac install` to consider podman
- Added consideration for all runnable commands
- Fixed `plextrac info` to show actual image version instead of the image hash
- Added `plextrac autocomplete` command to enable tab completion of manager utility commands
- Added Redis healthcheck
- Deprecated `migrate` command and removed from help screen


## Tests -- **Passing**
<details>
<b>Podman only supported on RHEL 8/9. Tests were run on the below OS's but podman specifically wasn't tested outside RHEL 8/9</b>


| Complete  | Command | OS Support |
| :-------------: | :------------- | :-------------: |
| ✅   | `autocomplete` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `backup` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `clean` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `dist` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `info` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `install` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `restore` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `stop` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `version` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `autofix` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `check` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `configure` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `help` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `initialize` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `logs` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `reload-cert` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `start` | `[RHEL 9, Ubuntu 22.04]` |
| ✅   | `update` | `[RHEL 9, Ubuntu 22.04]` |

</details>