### PR TITLE
Bugfix: Image Registry logic correction

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.9
+current_version = 0.5.10
 commit = True
 tag = True
 

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -113,16 +113,22 @@ function login_dockerhub() {
   log "${GREEN}DockerHUB${RESET}: SUCCESS"
 
   if [ -n "${IMAGE_REGISTRY:-}" ]; then
-  debug "Custom Image Registry Found..."
-  debug "Attempting login"
-    if [ -z "${IMAGE_REGISTRY_PASS:-}" ]; then
-      die "ERROR: Image registry password not found, please set IMAGE_REGISTRY_PASS in the .env and re-run configuration"
-    fi
+    debug "Custom Image Registry Found..."
+    debug "Attempting login"
     if [ -z "${IMAGE_REGISTRY_USER:-}" ]; then
-      die "ERROR: Image registry username not found, please set IMAGE_REGISTRY_USER in the .env and re-run configuration"
+      debug "$IMAGE_REGISTRY username not found, continuing..."
+      local image_user=""
+    else 
+      local image_user="-u ${IMAGE_REGISTRY_USER:-}"
     fi
-    output="$(docker login ${IMAGE_REGISTRY} -u ${IMAGE_REGISTRY_USER} --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}")" || die "${output}"
-    debug "$output"
+
+    if [ -z "${IMAGE_REGISTRY_PASS:-}" ]; then
+      debug "$IMAGE_REGISTRY password not found, continuing..."
+      local image_pass=""
+      docker login ${IMAGE_REGISTRY} $image_user || die "Failed to login to ${IMAGE_REGISTRY}"
+    else
+      docker login ${IMAGE_REGISTRY} $image_user --password-stdin 2>&1 <<< "${IMAGE_REGISTRY_PASS}" || die "Failed to login to ${IMAGE_REGISTRY}"
+    fi
     log "${BLUE}$IMAGE_REGISTRY${RESET}: SUCCESS"
   fi
   log "Done."

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.5.9
+VERSION=0.5.10
 
 trap 'cleanup $?' SIGINT ERR EXIT
 


### PR DESCRIPTION
- Expanded to allow an `IMAGE_REGISTRY` to be specified without requiring a username / password
- Allow specification of the `IMAGE_REGISTRY_USER` without the need for `IMAGE_REGISTRY_PASS` for public or proxy repos