### PR TITLE
Update: Remove UID Dependencies

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 
 commit = True
 tag = True

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.1
+current_version = 0.6.2
 
 commit = True
 tag = True

--- a/src/_backup.sh
+++ b/src/_backup.sh
@@ -48,8 +48,9 @@ function backup_fullCouchbaseBackup() {
     cmd='docker exec'
   fi
   if [ "$CONTAINER_RUNTIME" != "podman" ]; then
+  local user_id=$(id -u plextrac)
     debug "`$cmd $couchbaseComposeService \
-      chown -R 1337:1337 /backups 2>&1`"
+      chown -R $user_id:$user_id /backups 2>&1`"
   fi
   debug "`$cmd $couchbaseComposeService \
     cbbackup -m full "http://127.0.0.1:8091" /backups -u ${CB_BACKUP_USER} -p ${CB_BACKUP_PASS} 2>&1`"
@@ -66,8 +67,9 @@ function backup_fullPostgresBackup() {
   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
     cmd='docker exec'
   fi
+  local user_id=$(id -u plextrac)
   if [ "$CONTAINER_RUNTIME" != "podman" ]; then
-    debug "`compose_client exec -T $postgresComposeService chown -R 1337:1337 /backups 2>&1`"
+    debug "`compose_client exec -T $postgresComposeService chown -R $user_id:$user_id /backups 2>&1`"
   fi
   backupTimestamp=$(date -u "+%Y-%m-%dT%H%M%Sz")
   targetPath=/backups/$backupTimestamp

--- a/src/_backup.sh
+++ b/src/_backup.sh
@@ -34,7 +34,7 @@ function backup_fullUploadsBackup() {
     podman exec --workdir="/usr/src/plextrac-api/uploads" plextracapi rm $current_date.tar.gz
     debug "Cleaned Archive from container"
   else
-    debug "`compose_client run --user 1337 -v ${uploadsBackupDir}:/backups \
+    debug "`compose_client run --user $(id -u) -v ${uploadsBackupDir}:/backups \
       --workdir /usr/src/plextrac-api --rm --entrypoint='' -T  $coreBackendComposeService \
       tar -czf /backups/$(date -u "+%Y-%m-%dT%H%M%Sz").tar.gz uploads`"
   fi
@@ -43,12 +43,12 @@ function backup_fullUploadsBackup() {
 
 function backup_fullCouchbaseBackup() {
   info "$couchbaseComposeService: Performing backup of couchbase database"
-  local cmd='compose_client exec -T --user 1337'
+  local user_id=$(id -u plextrac)
+  local cmd="compose_client exec -T --user $user_id"
   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
     cmd='docker exec'
   fi
   if [ "$CONTAINER_RUNTIME" != "podman" ]; then
-  local user_id=$(id -u plextrac)
     debug "`$cmd $couchbaseComposeService \
       chown -R $user_id:$user_id /backups 2>&1`"
   fi
@@ -63,11 +63,11 @@ function backup_fullCouchbaseBackup() {
 
 function backup_fullPostgresBackup() {
   info "$postgresComposeService: Performing backup of postgres database"
-  local cmd='compose_client exec -T --user 1337'
+  local user_id=$(id -u plextrac)
+  local cmd="compose_client exec -T --user $user_id"
   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
     cmd='docker exec'
   fi
-  local user_id=$(id -u plextrac)
   if [ "$CONTAINER_RUNTIME" != "podman" ]; then
     debug "`compose_client exec -T $postgresComposeService chown -R $user_id:$user_id /backups 2>&1`"
   fi

--- a/src/_check.sh
+++ b/src/_check.sh
@@ -47,15 +47,17 @@ function mod_etl_fix() {
       info "Checking volume permissions"
       if [ "$owner" != "plextrac" ]
         then
+          local user_id=$(id -u plextrac)
           info "Volume permissions are wrong; initiating fix"
-          compose_client exec -u 0 plextracapi chown -R 1337:1337 uploads/etl-logs
+          compose_client exec -u 0 plextracapi chown -R $user_id:$user_id uploads/etl-logs
       else
         info "Volume permissions are correct"
       fi
     else
       info "Fixing ETL Folder creation"
       compose_client exec plextracapi mkdir uploads/etl-logs
-      compose_client exec plextracapi chown -R 1337:1337 uploads/etl-logs
+      local user_id=$(id -u plextrac)
+      compose_client exec plextracapi chown -R $user_id:$user_id uploads/etl-logs
     fi
   fi
 }

--- a/src/_clean.sh
+++ b/src/_clean.sh
@@ -54,9 +54,10 @@ function clean_compressCouchbaseBackups() {
     -exec tar --remove-files -czvf /backups/{}.tar.gz {} \;
     2>&1`"
   debug "Fixing permissions on backups"
+  local user_id=$(id -u plextrac)
   debug "`$cmd --entrypoint= --workdir /backups $image \
     find . -maxdepth 1 -type f -name '*.tar.gz' \
-    -exec chown 1337:1337 {} \;
+    -exec chown $user_id:$user_id {} \;
     2>&1`"
   log "Done."
 }

--- a/src/_cli_common_utilities.sh
+++ b/src/_cli_common_utilities.sh
@@ -31,7 +31,7 @@ function requires_user_root() {
 }
 
 function requires_user_plextrac {
-  if [ "$EUID" -ne 1337 ]; then
+  if [ "$EUID" -ne $(id -u plextrac) ]; then
     die "${RED}Please run as plextrac user${RESET}"
   fi
 }

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -2,7 +2,7 @@ function create_user() {
   if ! id -u "plextrac" >/dev/null 2>&1
   then
     info "Adding plextrac user..."
-    local user_id=""
+    local user_id="-u 1337"
     if [ "${PLEXTRAC_USER_ID:-}" ]; then
       local user_id="-u ${PLEXTRAC_USER_ID}"
     fi

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -2,12 +2,16 @@ function create_user() {
   if ! id -u "plextrac" >/dev/null 2>&1
   then
     info "Adding plextrac user..."
+    local user_id=""
+    if [ "${PLEXTRAC_USER_ID:-}" ]; then
+      local user_id="-u ${PLEXTRAC_USER_ID}"
+    fi
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-      useradd --shell /bin/bash \
+      useradd --shell /bin/bash $user_id \
               --create-home --home "${PLEXTRAC_HOME}" \
               plextrac
     else
-      useradd --groups docker \
+      useradd $user_id --groups docker \
               --shell /bin/bash \
               --create-home --home "${PLEXTRAC_HOME}" \
               plextrac

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -16,6 +16,11 @@ function create_user() {
               --create-home --home "${PLEXTRAC_HOME}" \
               plextrac
     fi
+    if ! id -g "plextrac" >/dev/null 2>&1
+    then
+      groupadd -g $(id -u plextrac) plextrac
+    fi
+    usermod -g plextrac plextrac
     log "Done."
   fi
 }

--- a/src/_initialize_user.sh
+++ b/src/_initialize_user.sh
@@ -1,17 +1,13 @@
 function create_user() {
-  # create "plextrac" user with UID/GID 1337 to match the UID/GID of the container user
-  # this is required for anything in the uploads directory to
   if ! id -u "plextrac" >/dev/null 2>&1
   then
     info "Adding plextrac user..."
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-      useradd --uid 1337 \
-              --shell /bin/bash \
+      useradd --shell /bin/bash \
               --create-home --home "${PLEXTRAC_HOME}" \
               plextrac
     else
-      useradd --uid 1337 \
-              --groups docker \
+      useradd --groups docker \
               --shell /bin/bash \
               --create-home --home "${PLEXTRAC_HOME}" \
               plextrac

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -55,7 +55,7 @@ function restore_doCouchbaseRestore() {
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
       podman exec --workdir /backups $couchbaseComposeService tar -xzvf /backups/$backupFile
     else
-      debug "`compose_client exec -T --user 1337 --workdir /backups $couchbaseComposeService \
+      debug "`compose_client exec -T --user $(id -u plextrac) --workdir /backups $couchbaseComposeService \
         tar -xzvf /backups/$backupFile 2>&1`"
     fi
 
@@ -75,7 +75,7 @@ function restore_doCouchbaseRestore() {
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
       podman exec --workdir /backups $couchbaseComposeService rm -rf /backups/$dirName
     else
-      debug "`compose_client exec -T --user 1337 --workdir /backups $couchbaseComposeService \
+      debug "`compose_client exec -T --user $(id -u plextrac) --workdir /backups $couchbaseComposeService \
         rm -rf /backups/$dirName 2>&1`"
     fi
     log "Done"
@@ -95,7 +95,7 @@ function restore_doPostgresRestore() {
     databaseBackups=$(basename -s .psql `tar -tf $latestBackup | awk '/.psql/{print $1}'`)
     log "Restoring from $backupFile"
     log "Databases to restore:\n$databaseBackups"
-    local cmd='compose_client exec -T --user 1337'
+    local cmd="compose_client exec -T --user $(id -u plextrac)"
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
       local cmd='podman exec'
     fi

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -37,9 +37,10 @@ function restore_doUploadsRestore() {
 function restore_doCouchbaseRestore() {
   title "Restoring Couchbase from backup"
   debug "Fixing permissions"
+  local user_id=$(id -u plextrac)
   if [ "$CONTAINER_RUNTIME" == "docker" ]; then
     debug "`compose_client exec -T $couchbaseComposeService \
-      chown -R 1337:1337 /backups 2>&1`"
+      chown -R $user_id:$user_id /backups 2>&1`"
   fi
   latestBackup="`ls -dc1 ${PLEXTRAC_BACKUP_PATH}/couchbase/* | head -n1`"
   backupFile=`basename $latestBackup`

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.6.0
+VERSION=0.6.1
 
 
 ## Podman Global Declaration Variable

--- a/src/plextrac
+++ b/src/plextrac
@@ -138,6 +138,7 @@ function mod_help() {
   log " -d | --debug                        ${DIM}enables debug output VERY NOISY${RESET}"
   log " -v | --verbose                      ${DIM}enables verbose output, helpful for troubleshooting errors${RESET}"
   log " -y | --assume-yes                   ${DIM}assumes yes to all questions in script${RESET}"
+  log " --uid | --user-id                   ${DIM}during initialization, assign a specific user ID on 'plextrac' user creation${RESET}"
   log " --install-dir | --plextrac-home     ${DIM}path to non-standard install directory. The default is /opt/plextrac${RESET}"
   log " --install-timeout NUM               ${DIM}seconds to wait for install migrations to complete. The default is 600 (10 mins)${RESET}"
 }
@@ -221,6 +222,11 @@ function main() {
         ;;
       "-c" | "--container-runtime")
         CONTAINER_RUNTIME=$2
+        shift
+        shift
+        ;;
+      "-uid" | "--user-id")
+        PLEXTRAC_USER_ID=${2:-}
         shift
         shift
         ;;

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.6.1
+VERSION=0.6.2
 
 
 ## Podman Global Declaration Variable


### PR DESCRIPTION
Goal:
Update old logic to remove strict need to run as user `1337` as this can cause collisions with user provisioning and JIT solutions for the host OS

Task List:
- [x] Adjusted user requirement to require 'plextrac' user regardless of uid
- [x] Adjusted user creation to remove static assignment of the uid allowing for creation of an open UID on initialize
- [x] Create ability to ASSIGN uid on running `plextrac initialize`
- [x] Test permissions with volume binds / mounts
- [x] Test Backup and Restore processes
- [x] Test backwards compatibility with ownership by `1337`
- [x] QA full spectrum testing to catch permission / usage issues