### PR TITLE
Add missing env var to notification-sender service

### DIFF
--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -184,6 +184,7 @@ services:
       REDIS_CONNECTION_STRING: "${REDIS_CONNECTION_STRING:-redis}"
       REDIS_PASSWORD: "${REDIS_PASSWORD:?err}"
       serviceConfig: ${serviceConfig:-}
+      API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE: "${API_INTEGRATION_AUTH_CONFIG_NOTIFICATION_SERVICE:?err}"
     healthcheck:
       test:
       - "CMD"


### PR DESCRIPTION
Fixes a bug that is preventing emails from sending due to the notification-sender service not being able to make requests to our api because of a missing auth token.

Note: This is the same env var that the notification-engine service already has, but the notification-sender service needs it as well now.