### PR TITLE
Bugfix: Variable for `plextrac util-update` breaking updates

### DIFF
--- a/src/_update.sh
+++ b/src/_update.sh
@@ -199,7 +199,7 @@ function selfupdate_doUpgrade() {
   debug "Initially called '$ProgName' w/ args '$_INITIAL_CMD_ARGS'" 
   debug "Script Backup: `sha256sum ${target}.bak`"
   debug "Script Update: `sha256sum $target`"
-  if [ "$SKIP_APP_UPDATE" == "true" ]; then
+  if [ "${SKIP_APP_UPDATE:-false}" == "true" ]; then
     exit 0
   fi
   eval "SKIP_SELF_UPGRADE=1 $ProgName $_INITIAL_CMD_ARGS"


### PR DESCRIPTION
Fixed the bad declaration of the variable SKIP_APP_UPDATE