### PR TITLE
Added new function to control CKE migration with cli flag

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.7
+current_version = 0.6.8
 
 commit = True
 tag = True

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -237,6 +237,7 @@ function getCKEditorRTCConfig() {
     while read -r line; do
       logger -t ckeditor-migration $line
     done <<< "$CKEDITOR_LOGS_OUTPUT"
+    echo "$CKEDITOR_LOGS_OUTPUT" > ${PLEXTRAC_HOME}/ckeditor-migration.log
 
     # check the result to confirm it contains the expected element in the JSON, then base64 encode if it does
     if [ "$(echo "$CKEDITOR_JSON" | jq -e ".[] | any(\".api_secret\")")" ]; then

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -255,6 +255,7 @@ function getCKEditorRTCConfig() {
   fi
 }
 
+# This will ensure that the two services for CKE are stood up and functional before we run the Environment or the RTC migrations
 function ckeditorNginxConf() {
   debug "Enabling proxy for CKEditor Backend and NGINX Proxy settings"
   compose_client up -d ckeditor-backend

--- a/src/_configure_plextrac.sh
+++ b/src/_configure_plextrac.sh
@@ -254,3 +254,9 @@ function getCKEditorRTCConfig() {
     debug "CKEditor service not found; migration has not been run"
   fi
 }
+
+function ckeditorNginxConf() {
+  debug "Enabling proxy for CKEditor Backend and NGINX Proxy settings"
+  compose_client up -d ckeditor-backend
+  compose_client up -d plextracnginx --force-recreate
+}

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -139,6 +139,9 @@ function plextrac_install_podman() {
   fi
 
   mod_start "${INSTALL_WAIT_TIMEOUT:-600}" # allow up to 10 or specified minutes for startup on install, due to migrations
+  podman rm -f plextracapi
+  mod_start
+  
   mod_info
   info "Post installation note:"
   log "If you wish to have access to historical logs, you can configure docker to send logs to journald."

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -27,6 +27,10 @@ function mod_update() {
   # Check upstream tags avaialble to download
   mod_configure
   version_check
+  if [ "${MIGRATE_CKE:-false}" == "true" ]; then
+    debug "Enabling Environment and RTC Migration"
+    ckeditorNginxConf
+  fi
   if $contiguous_update
     then
       debug "Proceeding with contiguous update"

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.6.7
+VERSION=0.6.8
 
 ## Podman Global Declaration Variable
 declare -A svcValues

--- a/src/plextrac
+++ b/src/plextrac
@@ -227,6 +227,12 @@ function main() {
         shift
         shift
         ;;
+      "-cke" | "--cke-migration")
+        IGNORE_ETL_STATUS="true"
+        MIGRATE_CKE="true"
+        shift
+        shift
+        ;;
       *)
         if declare -f mod_$1 >/dev/null 2>&1; then
           # enable event logging for sub commands

--- a/src/plextrac
+++ b/src/plextrac
@@ -231,7 +231,6 @@ function main() {
         IGNORE_ETL_STATUS="true"
         MIGRATE_CKE="true"
         shift
-        shift
         ;;
       *)
         if declare -f mod_$1 >/dev/null 2>&1; then

--- a/src/plextrac
+++ b/src/plextrac
@@ -366,12 +366,8 @@ function mod_install() {
       ckeditorNginxConf
     fi
     getCKEditorRTCConfig
-    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-      podman rm -f plextracapi
-      mod_start
-    else
-      compose_client up -d "$coreBackendComposeService" --force-recreate
-    fi
+    compose_client up -d "$coreBackendComposeService" --force-recreate
+
     mod_info
     info "Post installation note:"
     log "If you wish to have access to historical logs, you can configure docker to send logs to journald."

--- a/src/plextrac
+++ b/src/plextrac
@@ -362,6 +362,9 @@ function mod_install() {
     pull_docker_images
     mod_start "${INSTALL_WAIT_TIMEOUT:-600}" # allow up to 10 or specified minutes for startup on install, due to migrations
     # Configure the CKEditor RTC service as part of the install, which also requires a recreate of the backend
+    if [ "${MIGRATE_CKE:-false}" == "true" ]; then
+      ckeditorNginxConf
+    fi
     getCKEditorRTCConfig
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
       podman rm -f plextracapi


### PR DESCRIPTION
- Added new CLI flag `-cke | --cke-migration` to be used when updating to enable CKE

The system would mean enabling the environment variable, adding the service declarations into docker-compose, adding the new dockerhub token, and then running `plextrac update -v -cke`