### PR TITLE
Added version comparison for post 1.6 for etl check

### DIFF
--- a/src/_version_check.sh
+++ b/src/_version_check.sh
@@ -25,7 +25,7 @@ function version_check() {
   ## LOGIC: RunVer
   debug "Running Version"
   # Get running version of Backend
-    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
     running_backend_version="$(for i in $(podman ps -a -q --filter name=plextracapi); do podman inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
   else
     running_backend_version="$(for i in $(compose_client ps plextracapi -q); do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"


### PR DESCRIPTION
- This is due to the script timing out / breaking on version 1.57 specifically, but we don't need ETL locking for updates until 2.0