### PR TITLE
Bugfix: Messaging Clarity

### DIFF
--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -158,7 +158,7 @@ function mod_check_etl_status() {
       local migration_exited=$(docker inspect --format '{{.State.Status}}' `docker ps -a | grep migrations 2>/dev/null | awk '{print $1}'` || migration_exited="exited")
     fi
     if [ $(date +%s) -gt $endTime ]; then
-      error "Migration container has been running for over 5 minutes or is still running.Please ensure they complete or fail before taking further action with the PlexTrac Manager Utility. You can check on the logs by running 'docker compose logs -f couchbase-migrations'"
+      error "Migration container has been running for over 5 minutes or is still running. Please ensure they complete or fail before taking further action with the PlexTrac Manager Utility. You can check on the logs by running 'docker compose logs -f couchbase-migrations'"
       die "Exiting PlexTrac Manager Utility."
     fi
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -158,7 +158,8 @@ function mod_check_etl_status() {
       local migration_exited=$(docker inspect --format '{{.State.Status}}' `docker ps -a | grep migrations 2>/dev/null | awk '{print $1}'` || migration_exited="exited")
     fi
     if [ $(date +%s) -gt $endTime ]; then
-      die "Migration container has been running for over 5 minutes or is still running. Exiting..."
+      error "Migration container has been running for over 5 minutes or is still running.Please ensure they complete or fail before taking further action with the PlexTrac Manager Utility. You can check on the logs by running 'docker compose logs -f couchbase-migrations'"
+      die "Exiting PlexTrac Manager Utility."
     fi
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
       for s in / - \\ \|; do printf "\r\033[K$s $(podman inspect --format '{{.State.Status}}' migrations) -- $(podman logs migrations 2> /dev/null | tail -n 1 -q)"; sleep .1; done

--- a/src/_stop.sh
+++ b/src/_stop.sh
@@ -31,5 +31,5 @@ function mod_stop() {
     compose_client stop
   fi
   info "-----"
-  info "PlexTrac stopped. It's now safe to update and restart"
+  info "PlexTrac stopped. It's now safe to update the OS and restart"
 }


### PR DESCRIPTION
- Adjusted the wording for clarity in the `plextrac stop` command
- Adjusted the wording for clarity when the manager utility exits for running too long