### PR TITLE
Bugfix: Backup of Uploads with unintended dependency

### DIFF
--- a/src/_backup.sh
+++ b/src/_backup.sh
@@ -34,7 +34,7 @@ function backup_fullUploadsBackup() {
     podman exec --workdir="/usr/src/plextrac-api/uploads" plextracapi rm $current_date.tar.gz
     debug "Cleaned Archive from container"
   else
-    debug "`compose_client run --user $(id -u) -v ${uploadsBackupDir}:/backups \
+    debug "`compose_client run --user $(id -u) --no-deps -v ${uploadsBackupDir}:/backups \
       --workdir /usr/src/plextrac-api --rm --entrypoint='' -T  $coreBackendComposeService \
       tar -czf /backups/$(date -u "+%Y-%m-%dT%H%M%Sz").tar.gz uploads`"
   fi


### PR DESCRIPTION
## Changes
- Added `--no-deps` to the backing up of the uploads container
- This is for a niche use-case where a docker-compose change is staged, but not implemented through a docker command. This will prevent a `plextrac backup` command to recreate any of the needful dependencies for a backup and fail instead.

## Testing
- [x] OS Tests [Ubuntu, Rocky Linux, RHEL 8/9]
- [x] Upload backup integrity after change [Comparison and evaluation of date integrity]
- [x] State variations [app version, app state]