### PR TITLE
Bugfix: Migration logs, `plextrac info` postgres bug, better messaging

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.6
+current_version = 0.7.7
 
 commit = True
 tag = True

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -1,6 +1,24 @@
+# Podman
+
+This is a very basic guide to using Podman and explaining how it works a bit
+
+## How To's
+
+### Using Custom SSL Certificates and Custom Logos
+
+The Custom SSL Certificates and Custom Logos are mounted at the following locations:
+
+```shell
+"${PLEXTRAC_HOME:-.}/volumes/nginx_ssl_certs"
+"${PLEXTRAC_HOME:-.}/volumes/nginx_logos"
+```
+
+To use a Custom SSL Certificate or Logo, simply navigate to this location on the HOST OS, replace the files present there with the appropriate replacements, and then restart the NGINX container `podman restart plextracnginx`
+
 ## Additional Package Requirements
 
 podman | >=v4.6 (RHEL 8/9 only)
+`jq`, `bc`, `bash v5+`, and `wget`
 
 ## Podman support
 
@@ -9,11 +27,11 @@ We've expanded the capabilities to support podman in specific circumstances.
 *OS:* RHEL 8/9+
 *Podman Compose:* No (currently)
 
-> Note: the module for podman was written with RHEL 9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.
-
-> Note: All testing has been done on BASE images without hardening with a security profile or SELinux or anything -- its just a stock operating system
+> Note: the module for podman was written with RHEL 8/9 specifically in mind. It is not officially supported at this time to use the container runtime set to Podman on Debian, Ubuntu, or CentOS.
+> Note: All testing has been done on BASE images without hardening with a security profile or SELinux or anything -- its just a stock operating system.
 
 ---
+
 
 ### Podman Troubleshooting
 

--- a/src/_info.sh
+++ b/src/_info.sh
@@ -126,7 +126,7 @@ function _getServiceContainerVersion() {
         if [ "$CONTAINER_RUNTIME" == "podman" ]; then
           version=$(podman image inspect $imageId --format '{{ index .Annotations "org.opencontainers.image.version" }}' 2>/dev/null || echo '')
         else
-          version=$(docker image inspect postgres:14-alpine --format '{{range $index, $value := .Config.Env}}{{$value}}{{"\n"}}{{end}}' | grep PG_VERSION | cut -d '=' -f2 || echo '')
+          version=$(docker image inspect $imageId --format '{{range $index, $value := .Config.Env}}{{$value}}{{"\n"}}{{end}}' | grep PG_VERSION | cut -d '=' -f2 || echo '')
         fi
         ;;
       "redis")

--- a/src/_update.sh
+++ b/src/_update.sh
@@ -49,6 +49,7 @@ function mod_update() {
       for i in ${upgrade_path[@]}
         do
           if [ "$i" != "$running_ver" ]; then
+            info "Starting Update..."
             debug "Upgrading to $i"
             getCKEditorRTCConfig
             mod_configure
@@ -85,6 +86,7 @@ function mod_update() {
       mod_check_etl_status "${ETL_OUTPUT-}"
       title "Update complete"
   else
+      info "Starting Update..."
       debug "Proceeding with normal update"
       getCKEditorRTCConfig
       mod_configure

--- a/src/plextrac
+++ b/src/plextrac
@@ -450,7 +450,14 @@ function run_cb_migrations() {
       info "Migrations completed"
       break
     fi
-    for s in / - \\ \|; do printf "\r\033[K$s $(container_client inspect --format '{{.State.Status}}' `container_client ps -a | grep migrations 2>/dev/null | awk '{print $1}'`) -- $(container_client logs `container_client ps -a | grep migrations 2>/dev/null | awk '{print $1}'` 2> /dev/null | tail -n 1 -q)"; sleep .1; done
+    for s in / - \\ \|; do
+        local log=""
+        local container=""  
+        container="$(container_client ps -a | grep migrations 2>/dev/null | awk '{print $1}')"
+        log="$(container_client logs $container 2> /dev/null | tail -n 1 -q || true)"
+        printf "\r\033[K%s %s -- %s" "$s" "$container" "$log"
+        sleep .1
+    done
     sleep 1
   done
   if [ $(date +%s) -ge $endTime ]; then

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.7.6
+VERSION=0.7.7
 
 ## Podman Global Declaration Variable
 declare -A svcValues


### PR DESCRIPTION
- Fixed warning about missing postgres container when running `plextrac info`
- Fixed `printf` usage when it's printing container logs to console and won't abort with 2.9 update
- Added "Update started" message after acknowledging warning so the user know's it didn't freeze
- Updated some Podman Documentation