### PR TITLE
fix typo on image for ckeditor-backend

### DIFF
--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -33,7 +33,7 @@ function plextrac_install_podman() {
   PODMAN_REDIS_IMAGE="${PODMAN_REDIS_IMAGE:-docker.io/redis:6.2-alpine}"
   PODMAN_API_IMAGE="${PODMAN_API_IMAGE:-docker.io/plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}}"
   PODMAN_NGINX_IMAGE="${PODMAN_NGINX_IMAGE:-docker.io/plextrac/plextracnginx:${UPGRADE_STRATEGY:-stable}}"
-  PODMAN_CKE_IMAGE="${PODMAN_CKE_IMAGE:-docker.cke.cke-cs.com/cs:4.17.1}"
+  PODMAN_CKE_IMAGE="${PODMAN_CKE_IMAGE:-docker.cke-cs.com/cs:4.17.1}"
 
   serviceValues[ckeditor-backend-image]="${PODMAN_CKE_IMAGE}"
   serviceValues[cb-image]="${PODMAN_CB_IMAGE}"
@@ -157,7 +157,7 @@ function plextrac_start_podman() {
   PODMAN_REDIS_IMAGE="${PODMAN_REDIS_IMAGE:-docker.io/redis:6.2-alpine}"
   PODMAN_API_IMAGE="${PODMAN_API_IMAGE:-docker.io/plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}}"
   PODMAN_NGINX_IMAGE="${PODMAN_NGINX_IMAGE:-docker.io/plextrac/plextracnginx:${UPGRADE_STRATEGY:-stable}}"
-  PODMAN_CKE_IMAGE="${PODMAN_CKE_IMAGE:-docker.cke.cke-cs.com/cs:4.17.1}"
+  PODMAN_CKE_IMAGE="${PODMAN_CKE_IMAGE:-docker.cke-cs.com/cs:4.17.1}"
 
   serviceValues[ckeditor-backend-image]="${PODMAN_CKE_IMAGE}"
   serviceValues[cb-image]="${PODMAN_CB_IMAGE}"


### PR DESCRIPTION
Ignore the name of the branch. I thought there was an issue with the DB initialization, but it appears to have been an issue with ckeditor instead