### PR TITLE
Updates HealthCheck Endpoint For API Container And AI SQL USER Fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.20
+current_version = 0.7.21
 
 commit = True
 tag = True

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.7.20
+VERSION=0.7.21
 
 ## Podman Global Declaration Variable
 declare -A svcValues
@@ -22,7 +22,7 @@ svcValues[pg-healthcheck]='--health-cmd=["pg_isready","-U","internalonly"]'
 svcValues[pg-env-vars]="-e 'POSTGRES_HOST_AUTH_METHOD=scram-sha-256' -e 'PG_MIGRATE_PATH=/usr/src/plextrac-api' -e 'PGDATA=/var/lib/postgresql/data/pgdata'"
 #API
 svcValues[api-volumes]="-v uploads:/usr/src/plextrac-api/uploads:Z,U -v localesOverride:/usr/src/plextrac-api/localesOverride:rw"
-svcValues[api-healthcheck]='--health-cmd=["wget","-q","-O-","http://127.0.0.1:4350/api/v2/health/live"]'
+svcValues[api-healthcheck]='--health-cmd=["wget","-q","-O-","http://127.0.0.1:4350/api/v2/health/full"]'
 #Redis
 svcValues[redis-volumes]="-v redis:/etc/redis:rw"
 svcValues[redis-healthcheck]='--health-cmd=["redis-cli","--raw","incr","ping"]'

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
       PG_CORE_RW_PASSWORD: ${PG_CORE_RW_PASSWORD:?err}
       PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
+      PG_CORE_AI_SQL_PASSWORD: ${PG_CORE_AI_SQL_PASSWORD:?err}
+      PG_CORE_AI_SQL_USER: ${PG_CORE_AI_SQL_USER:?err}
 
   plextracdb:
     environment:


### PR DESCRIPTION
Removes the old endpoint used in previous versions of PlexTrac `http://127.0.0.1:4350/api/v2/health/live` in favor of the latest endpoint `http://127.0.0.1:4350/api/v2/health/full`