### PR TITLE
[AI-410] PG Init Update

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.28
+current_version = 0.7.29
 
 commit = True
 tag = True

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -106,6 +106,8 @@ for db_name in ${PGDATABASES[@]}; do
   ro_password="PG_${db_name_uppercase}_RO_PASSWORD"
   rw_user="PG_${db_name_uppercase}_RW_USER"
   rw_password="PG_${db_name_uppercase}_RW_PASSWORD"
+  ai_user="PG_CORE_AI_SQL_USER"
+  ai_password="PG_CORE_AI_SQL_PASSWORD"
   
   # Execute bootstrap template for all databases
   psql -a -v ON_ERROR_STOP=1 \
@@ -124,8 +126,8 @@ for db_name in ${PGDATABASES[@]}; do
   if [ "${db_name}" = "core" ]; then
     psql -a -v ON_ERROR_STOP=1 \
       -v db_name="${db_name}" \
-      -v pg_core_ai_sql_user="$PG_CORE_AI_SQL_USER" \
-      -v pg_core_ai_sql_password="$PG_CORE_AI_SQL_PASSWORD" \
+      -v pg_core_ai_sql_user="${!ai_user}" \
+      -v pg_core_ai_sql_password="${!ai_password}" \
       --username $POSTGRES_USER \
       -d ${db_name} \
       < /docker-entrypoint-initdb.d/ai-sql-user.sql.txt

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -26,7 +26,7 @@ function deploy_volume_contents_postgres() {
     targetDir="${PLEXTRAC_HOME}/volumes/postgres-initdb"
   else
     targetDir=`compose_client config --format=json | jq -r \
-      '.volumes[] | select(.name | test("postgres-initdb")) | 
+      '.volumes[] | select(.name | test("postgres-initdb")) |
         .driver_opts.device'`
   fi
   debug "Adding scripts to $targetDir"
@@ -98,7 +98,7 @@ tmpl=`cat /docker-entrypoint-initdb.d/bootstrap-template.sql.txt`
 for db_name in ${PGDATABASES[@]}; do
   # Convert database name to uppercase for variable name construction
   db_name_uppercase=${db_name^^}
-  
+
   # Build environment variable names
   admin_user="PG_${db_name_uppercase}_ADMIN_USER"
   admin_password="PG_${db_name_uppercase}_ADMIN_PASSWORD"
@@ -108,7 +108,7 @@ for db_name in ${PGDATABASES[@]}; do
   rw_password="PG_${db_name_uppercase}_RW_PASSWORD"
   ai_user="PG_CORE_AI_SQL_USER"
   ai_password="PG_CORE_AI_SQL_PASSWORD"
-  
+
   # Execute bootstrap template for all databases
   psql -a -v ON_ERROR_STOP=1 \
     -v db_name="${db_name}" \
@@ -121,7 +121,7 @@ for db_name in ${PGDATABASES[@]}; do
     --username $POSTGRES_USER \
     -d $POSTGRES_USER \
     < /docker-entrypoint-initdb.d/bootstrap-template.sql.txt
-  
+
   # Execute AI SQL user creation only for core database
   if [ "${db_name}" = "core" ]; then
     psql -a -v ON_ERROR_STOP=1 \
@@ -150,7 +150,7 @@ function postgres_metrics_validation() {
       local container_runtime="container_client exec"
     fi
     debug "`$container_runtime -e PGPASSWORD=$POSTGRES_PASSWORD $postgresComposeService \
-        psql -a -v -U internalonly -d core 2>&1 <<- EOF 
+        psql -a -v -U internalonly -d core 2>&1 <<- EOF
 CREATE OR REPLACE FUNCTION __tmp_create_user() returns void as \\$\\$
 BEGIN
   IF NOT EXISTS (
@@ -287,6 +287,6 @@ function etl_failure() {
   sed -i "/^LOCK_VERSION/s/=.*$/=${LOCK_VERSION}/" "${PLEXTRAC_HOME}/.env"
   sed -i '/^LOCK_UPDATES/s/=.*$/=true/' "${PLEXTRAC_HOME}/.env"
   sed -i '/^UPGRADE_STRATEGY/s/=.*$/=NULL/' "${PLEXTRAC_HOME}/.env"
-  
+
   die "Updates are locked due to a failed data migration. Version Lock: $LOCK_VERSION. Continuing to attempt to update may result in data loss!!! Please contact PlexTrac Support"
 }

--- a/src/_manage_postgres.sh
+++ b/src/_manage_postgres.sh
@@ -76,38 +76,38 @@ ALTER DEFAULT PRIVILEGES FOR ROLE :'admin_user'
     GRANT USAGE ON SEQUENCES TO :'rw_user';
 
 -- AI SQL User (only for core database)
-DO $$ 
+DO $$
 BEGIN
   IF (:'db_name' = 'core') THEN
     CREATE USER :'pg_core_ai_sql_user' WITH PASSWORD :'pg_core_ai_sql_password';
-    
+
     -- Grant necessary permissions
     GRANT CONNECT ON DATABASE core TO :'pg_core_ai_sql_user';
     GRANT USAGE ON SCHEMA public TO :'pg_core_ai_sql_user';
-    
+
     -- Grant SELECT on specific tables and columns (similar to ai-user-etl.ts)
-    GRANT SELECT (cuid, id, tenant_id, name, description, created_at, last_updated_at) 
+    GRANT SELECT (cuid, id, tenant_id, name, description, created_at, last_updated_at)
       ON public.client TO :'pg_core_ai_sql_user';
-    
-    GRANT SELECT (cuid, id, tenant_id, tenant_cuid, client_id, name, description, status, 
-      start_date, end_date, report_type, reviewers, operators, custom_field, tags, 
-      created_at, last_updated_at) 
+
+    GRANT SELECT (cuid, id, tenant_id, tenant_cuid, client_id, name, description, status,
+      start_date, end_date, report_type, reviewers, operators, custom_field, tags,
+      created_at, last_updated_at)
       ON public.report TO :'pg_core_ai_sql_user';
-    
-    GRANT SELECT (cuid, flaw_id, tenant_id, client_id, report_id, description, status, 
-      sub_status, tags, title, severity, risk_score, recommendations, assigned_to_user_email, 
-      created_at, last_updated_at, reopened_at, closed_at) 
+
+    GRANT SELECT (cuid, flaw_id, tenant_id, client_id, report_id, description, status,
+      sub_status, tags, title, severity, risk_score, recommendations, assigned_to_user_email,
+      created_at, last_updated_at, reopened_at, closed_at)
       ON public.finding TO :'pg_core_ai_sql_user';
-    
-    GRANT SELECT (cuid, id, tenant_id, client_id, parent_id, name, type, known_ips, hostname, 
-      description, mac_address, netbios_name, dns_name, host_fqdn, host_rdns, system_owner, 
-      data_owner, physical_location, tags, criticality, operating_systems, pci_status, ports, 
-      integration_data, total_cves, created_at, last_updated_at) 
+
+    GRANT SELECT (cuid, id, tenant_id, client_id, parent_id, name, type, known_ips, hostname,
+      description, mac_address, netbios_name, dns_name, host_fqdn, host_rdns, system_owner,
+      data_owner, physical_location, tags, criticality, operating_systems, pci_status, ports,
+      integration_data, total_cves, created_at, last_updated_at)
       ON public.asset TO :'pg_core_ai_sql_user';
-    
-    GRANT SELECT (cuid, tenant_id, client_id, report_id, location_url, status, integration_data, 
-      created_at, last_updated_at, closed_at, reopened_at, finding_cuid, asset_cuid, 
-      assigned_to_user_email, sub_status) 
+
+    GRANT SELECT (cuid, tenant_id, client_id, report_id, location_url, status, integration_data,
+      created_at, last_updated_at, closed_at, reopened_at, finding_cuid, asset_cuid,
+      assigned_to_user_email, sub_status)
       ON public.asset_finding TO :'pg_core_ai_sql_user';
   END IF;
 END $$;

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -302,7 +302,7 @@ function podman_run_cb_migrations() {
   local image="${serviceValues[api-image]}"
 
   debug "Running migrations"
-  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:superuser:bootstrap && npm run pg:migrate && npm run pg:superuser:bootstrap:post-migration && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no \
+  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:superuser:bootstrap && npm run pg:migrate && npm run pg:superuser:bootstrap:post-migration --if-present && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no \
   $volumes:z --replace --name="migrations" ${serviceValues[network]} -d $image 1>/dev/null
 }
 

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -302,7 +302,7 @@ function podman_run_cb_migrations() {
   local image="${serviceValues[api-image]}"
 
   debug "Running migrations"
-  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:superuser:bootstrap --if-present && npm run pg:migrate && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no \
+  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:superuser:bootstrap && npm run pg:migrate && npm run pg:superuser:bootstrap:post-migration && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no \
   $volumes:z --replace --name="migrations" ${serviceValues[network]} -d $image 1>/dev/null
 }
 

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -302,7 +302,7 @@ function podman_run_cb_migrations() {
   local image="${serviceValues[api-image]}"
 
   debug "Running migrations"
-  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:superuser:bootstrap && npm run pg:migrate && npm run pg:superuser:bootstrap:post-migration --if-present && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no \
+  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run pg:superuser:bootstrap --if-present && npm run pg:migrate && npm run pg:superuser:bootstrap:post-migration --if-present && npm run db:migrate && npm run pg:etl up all && npm run maintenance:disable"]' --restart=no \
   $volumes:z --replace --name="migrations" ${serviceValues[network]} -d $image 1>/dev/null
 }
 

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.7.28
+VERSION=0.7.29
 
 ## Podman Global Declaration Variable
 declare -A svcValues

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     command: |
       sh -c
         "npm run maintenance:enable &&
-         npm run pg:superuser:bootstrap &&
+         npm run pg:superuser:bootstrap --if-present &&
          npm run pg:migrate &&
          npm run pg:superuser:bootstrap:post-migration --if-present &&
          npm run db:migrate &&

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -309,6 +309,8 @@ services:
       POSTGRES_INITDB_ARGS: '--auth-local=scram-sha-256 --auth-host=scram-sha-256'
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?err}
       POSTGRES_USER: ${POSTGRES_USER:?err}
+      PG_CORE_AI_SQL_PASSWORD: ${PG_CORE_AI_SQL_PASSWORD:-}
+      PG_CORE_AI_SQL_USER: ${PG_CORE_AI_SQL_USER:-}
     volumes:
     # this is where the initdb script & SQL template go
     - postgres-initdb:/docker-entrypoint-initdb.d

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -44,8 +44,9 @@ services:
     command: |
       sh -c
         "npm run maintenance:enable &&
-         npm run pg:superuser:bootstrap --if-present &&
+         npm run pg:superuser:bootstrap &&
          npm run pg:migrate &&
+         npm run pg:superuser:bootstrap:post-migration &&
          npm run db:migrate &&
          npm run pg:etl up all &&
          npm run maintenance:disable"

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         "npm run maintenance:enable &&
          npm run pg:superuser:bootstrap &&
          npm run pg:migrate &&
-         npm run pg:superuser:bootstrap:post-migration &&
+         npm run pg:superuser:bootstrap:post-migration --if-present &&
          npm run db:migrate &&
          npm run pg:etl up all &&
          npm run maintenance:disable"


### PR DESCRIPTION
<!-- Make sure the TITLE of your PR includes the Jira issue number, i.e. PDB-123 -->

## Summary

### _What_
PG Init Update: Create AI user on init, grant permissions post migration

### _Why_
- The AI SQL user is created by an ETL process (ai-user-etl.ts), not by standard PostgreSQL initialization scripts
- When a new PostgreSQL image is deployed (like the TimescaleDB update mentioned), the authentication system reinitializes
- Only users defined in bootstrap templates are automatically recreated during initialization
- This is standard PostgreSQL container behavior - authentication can be reinitialized separately from data


## Testing & Repro Steps
1. Ensure init works to create the AI user even when the ETL has not been run.

## Jira Issues

- https://plextrac.atlassian.net/browse/AI-410

## Related PRs
- https://github.com/PlexTrac/product-deploy-manifests/pull/375
- https://github.com/PlexTrac/plextrac-manager-util/pull/190
- https://github.com/PlexTrac/product-core-backend/pull/7191

<!--
### Some reminders that may or may not be relevant
**If this PR includes changes to `package.json`...**
* [ ] Have you included the modified `package-lock.json` in this PR?
* [ ] Are new packages added as `dependencies` or `devDependencies`? Please make sure you've made an intentional decision.

**If new `env` variables have been added...**
* [ ] Have you updated the `.env.example` file to provide example values?

**If the API schema has changed...**
* [ ] Does API documentation need to be updated? If this will be done later, please put a link to the Jira task for the documentation update above in the **Jira Issues** section.
-->
