### PR TITLE
Multiple bug fixes

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.34
+current_version = 0.7.35
 
 commit = True
 tag = True

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -44,7 +44,6 @@ function plextrac_install_podman() {
   serviceValues[redis-image]="${PODMAN_REDIS_IMAGE}"
   serviceValues[api-image]="${PODMAN_API_IMAGE}"
   serviceValues[plextracnginx-image]="${PODMAN_NGINX_IMAGE}"
-  serviceValues[env-file]="--env-file ${PLEXTRAC_HOME:-}/.env"
 
   serviceValues[env-file]="--env-file ${PLEXTRAC_HOME:-}/.env"
   serviceValues[redis-entrypoint]=$(printf '%s' "--entrypoint=" "[" "\"redis-server\"" "," "\"--requirepass\"" "," "\"${REDIS_PASSWORD}\"" "]")

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -110,7 +110,14 @@ function restore_doPostgresRestore() {
       mod_stop
 
       # recreate the postgres container
-      plextrac_start_podman postgres
+      # copied from the plextrac_install_podman function
+      local volumes="${serviceValues[pg-volumes]}"
+      local ports="${serviceValues[pg-ports]}"
+      local healthcheck="${serviceValues[pg-healthcheck]}"
+      local image="${serviceValues[pg-image]}"
+      local env_vars="${serviceValues[pg-env-vars]}"
+      container_client run "${serviceValues[env-file]}" "$env_vars" --restart=always "$healthcheck" \
+        "$volumes" --name="postgres" "${serviceValues[network]}" "$ports" -d "$image" 1>/dev/null
 
       # wait for postgres to be ready
       sleep 10

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -86,7 +86,11 @@ function restore_doPostgresRestore() {
   title "Restoring Postgres from backup"
 
   local plextrac_user_id=$(id -u ${PLEXTRAC_USER_NAME:-plextrac})
-  compose_files=$(for i in `ls -r ${PLEXTRAC_HOME}/docker-compose*.yml`; do printf " -f %s" "$i"; done )
+
+  # If docker runtime, gather a list of compose files
+  if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+    compose_files=$(for i in `ls -r ${PLEXTRAC_HOME}/docker-compose*.yml`; do printf " -f %s" "$i"; done )
+  fi
 
   latestBackup="`ls -dc1 ${PLEXTRAC_BACKUP_PATH}/postgres/* | head -n1`"
   backupFile=`basename $latestBackup`

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -86,6 +86,7 @@ function restore_doPostgresRestore() {
   title "Restoring Postgres from backup"
 
   local plextrac_user_id=$(id -u ${PLEXTRAC_USER_NAME:-plextrac})
+  PODMAN_PG_IMAGE="${PODMAN_PG_IMAGE:-docker.io/plextrac/plextracpostgres:stable}"
 
   # If docker runtime, gather a list of compose files
   if [ "$CONTAINER_RUNTIME" == "docker" ]; then
@@ -112,13 +113,13 @@ function restore_doPostgresRestore() {
 
       # recreate the postgres container
       # copied from the plextrac_install_podman function
-      local volumes="${serviceValues[pg-volumes]}"
-      local ports="${serviceValues[pg-ports]}"
-      local healthcheck="${serviceValues[pg-healthcheck]}"
-      local image="${serviceValues[pg-image]}"
-      local env_vars="${serviceValues[pg-env-vars]}"
-      container_client run "${serviceValues[env-file]}" "$env_vars" --restart=always "$healthcheck" \
-        "$volumes" --name="postgres" "${serviceValues[network]}" "$ports" -d "$image" 1>/dev/null
+      local volumes="${svcValues[pg-volumes]}"
+      local ports="${svcValues[pg-ports]}"
+      local healthcheck="${svcValues[pg-healthcheck]}"
+      local image="${PODMAN_PG_IMAGE}"
+      local env_vars="${svcValues[pg-env-vars]}"
+      container_client run --env-file ${PLEXTRAC_HOME:-}/.env "$env_vars" --restart=always "$healthcheck" \
+        "$volumes" --name="postgres" "${svcValues[network]}" "$ports" -d "$image" 1>/dev/null
 
       # wait for postgres to be ready
       sleep 10

--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -104,6 +104,7 @@ function restore_doPostgresRestore() {
     if [ "$CONTAINER_RUNTIME" == "podman" ]; then
       # Tear down the existing postgres container, including the related volumes
       podman stop postgres
+      podman rm postgres
       podman volume rm postgres-data
 
       # Stop the rest of the app

--- a/src/_stop.sh
+++ b/src/_stop.sh
@@ -9,8 +9,9 @@ function mod_stop() {
 
   # Before stopping, check if the current image tag matches the image defined by compose files.
   # Does not work with podman, so skipping that check if this is a podman environment.
+  # Also skipping if a new install with restore, since it will not have existing images to compare.
 
-  if [ "$CONTAINER_RUNTIME" == "docker" ]; then
+  if [ "$CONTAINER_RUNTIME" == "docker" ] && [ "${RESTOREONINSTALL:0}" -eq 0 ]; then
 
     debug "Validating the expected version against current running version"
     running_backend_version="$(for i in $(compose_client ps plextracapi -q); do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"
@@ -20,6 +21,13 @@ function mod_stop() {
     expected_backend_version="$(docker image inspect $expected_backend_tag --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")')"
     expected_frontend_version="$(docker image inspect $expected_frontend_tag --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")')"
 
+    # Check validity of variables
+    for v in running_backend_version running_frontend_version expected_backend_tag expected_frontend_tag expected_backend_version expected_frontend_version; do
+      if [ -z "${!v}" ]; then
+       error "Unknown value for ${v}"
+       die "Since 'plextrac stop' runs a docker compose down, we cannot guarantee a 'plextrac start' will bring up the correct version. Please double check your config and try again"
+      fi
+    done
 
     if [[ "$running_backend_version" != "$expected_backend_version" ]]; then
       error "The running backend version ${running_backend_version} does not match the expected version (${expected_backend_version})"

--- a/src/_stop.sh
+++ b/src/_stop.sh
@@ -11,7 +11,7 @@ function mod_stop() {
   # Does not work with podman, so skipping that check if this is a podman environment.
   # Also skipping if a new install with restore, since it will not have existing images to compare.
 
-  if [ "$CONTAINER_RUNTIME" == "docker" ] && [ "${RESTOREONINSTALL:0}" -eq 0 ]; then
+  if [ "$CONTAINER_RUNTIME" == "docker" ] && [ "${RESTOREONINSTALL:-0}" -eq 0 ]; then
 
     debug "Validating the expected version against current running version"
     running_backend_version="$(for i in $(compose_client ps plextracapi -q); do docker container inspect "$i" --format json | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version")'; done | sort -u)"

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.7.34
+VERSION=0.7.35
 
 ## Podman Global Declaration Variable
 declare -A svcValues


### PR DESCRIPTION
* fixes issue with `plextrac install --restore`
* Implemented timescaledb restore process for podman

## Testing:
* brand new install with `--restore` flag in both podman and docker compose env
* backup and restore podman environment and confirm the timescaledb tables, extension and triggers are all restored. 
* Verify permissions and insert capability