### PR TITLE
flush the redis cache after a restore

### DIFF
--- a/src/_restore.sh
+++ b/src/_restore.sh
@@ -188,5 +188,8 @@ function restore_doPostgresRestore() {
     log "now, start the rest of the app and sleep for 120s to give couchbase a chance"
     mod_start
     sleep 120
+
+    log "need to clear the license cache in redis so it properly uses the one from the restore"
+    compose_client exec -T --user $(id -u ${PLEXTRAC_USER_NAME:-plextrac}) redis redis-cli -a $REDIS_PASSWORD FLUSHALL
   fi
 }


### PR DESCRIPTION
### Testing
1. Fresh install
2. Configure with a license
3. Delete app and volumes
4. Re-install
5. Run restore
6. Tried restarting and recreating container, but this didn't work
7. Flush all solved issue
8. Run through repro steps again with the code for a flush all
9. Manually change cache value in Redis to test more quickly
10. Validate code is working correctly and addresses the licensing issue