### PR TITLE
Do not delete export_* files from uploads folder

### DIFF
--- a/src/_clean.sh
+++ b/src/_clean.sh
@@ -77,5 +77,5 @@ function clean_sweepUploadsCache() {
   fi
   # Leaving the cleanup fairly light, this should help a ton without getting aggressive
   debug "`$cmd -w /usr/src/plextrac-api/uploads plextracapi \
-    find . -maxdepth 1 -type f -regex '^.*\.\(json\|xml\|ptrac\|csv\|nessus\)$' -delete`"
+    find . -maxdepth 1 -type f -regex '^.*\.\(json\|xml\|ptrac\|csv\|nessus\)$' ! -name "export_*" -delete`"
 }

--- a/src/_clean.sh
+++ b/src/_clean.sh
@@ -77,5 +77,5 @@ function clean_sweepUploadsCache() {
   fi
   # Leaving the cleanup fairly light, this should help a ton without getting aggressive
   debug "`$cmd -w /usr/src/plextrac-api/uploads plextracapi \
-    find . -maxdepth 1 -type f -regex '^.*\.\(json\|xml\|ptrac\|csv\|nessus\)$' ! -name "export_*" -delete`"
+    find . -maxdepth 1 -type f -regex '^.*\.\(json\|xml\|ptrac\|csv\|nessus\)$' ! -name 'export_*' -delete`"
 }

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.7.42
+VERSION=0.7.43
 
 ## Podman Global Declaration Variable
 declare -A svcValues


### PR DESCRIPTION
These files are report export files. We've historically never allowed retrieval outside of the export endpoint where they're generated but we are going to begin to allow historically generated reports to be downloaded and tracked in the database. This means we can no longer delete them on a cron interval.

All generated exports should begin with the word `export_`