### PR TITLE
Update the manager util to use the UMF migration approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Please refer to `docs/getting-started.md` for usage instructions.
 
 Please refer to `docs/development.md` for development setup and contribution instructions.
 
+## Database migrations, UMF, and DVU (app v3.0+)
+
+- **UMF** (*Unified Migration Framework*) is the migration system in the application (e.g. `npm run db:migrate`) that can apply all pending migrations in order.
+- **DVU** (*Direct Version Upgrades*) is the *outcome*: upgrading across multiple minor versions in one step (one pull / one update) instead of stepping every release. **UMF is what makes DVU safe** once the app ships it—manager-util switches to the UMF path when you’re on a **v3.0+** image.
+
+**This CLI** (see `docs/development.md` and `plextrac migration-plan`): resolved app version **≥ 3.0** runs the **`unified-migrations`** Compose service (UMF chain); otherwise **`couchbase-migrations`** (legacy stepped-era chain). Optional break-glass: **`FORCE_LEGACY_MIGRATIONS=true`** forces legacy even on v3.x.
+
 ## Support
 
 Now officially supported on:

--- a/docs/development.md
+++ b/docs/development.md
@@ -80,3 +80,81 @@ Then run whatever cli command you were editing. i.e. `plextrac info`
     As a bonus, stack traces will be more useful as the line numbers and file references will point
     to the actual source files.
 
+## Testing UMF / DVU locally
+
+**UMF** (*Unified Migration Framework*) is the app’s unified migration runner. **DVU** (*Direct Version Upgrades*) is upgrading across version gaps in one go; UMF is what enables that once you’re on images that ship it.
+
+You can test the `unified-migrations` Compose service without a full v3 API image in some cases. Use the **live source**: `/vagrant/src/plextrac <command>` (Vagrant) or `./src/plextrac <command>` from the repo root (local).
+
+### How the script chooses unified vs legacy
+
+- **Rule:** resolved version **≥ v3.0** and **`FORCE_LEGACY_MIGRATIONS` is not `true`**
+  -> **`unified-migrations`** (UMF / `npm run db:migrate` chain — the path used for DVU on v3+).  
+  **Otherwise** -> **`couchbase-migrations`** (full legacy chain).  
+  There is no env flag to run UMF on **2.x**; those images are not expected to ship UMF.  
+  Pinned **`UPGRADE_STRATEGY`** and image labels use plain semver (**`2.26.5`**, **`3.0`**) — no **`v`** prefix.
+
+- **`USE_UMF`** is an internal boolean used by the script only (not an operator setting).
+
+- If **`UPGRADE_STRATEGY`** is `stable` (or another non-numeric tag), the version **must** be read
+  from **`org.opencontainers.image.version`** on the pulled `plextracapi` image. Missing or invalid
+  label -> **abort** (no silent fallback).
+
+### 0. Inspect the decision without running migrations
+
+From `/opt/plextrac` (or your `PLEXTRAC_HOME`) as the `plextrac` user, with `.env` loaded:
+
+      plextrac migration-plan
+
+This prints resolved version, whether it came from `.env` vs image label, and which compose service
+would run (`unified-migrations` vs `couchbase-migrations`).
+
+### 1. Legacy path (2.x)
+
+Resolved **2.x** -> **`couchbase-migrations`** always.
+
+- From Vagrant (as `plextrac` user, with `.env` in place):
+
+      cd /opt/plextrac
+      /vagrant/src/plextrac update -y
+
+- You should see the **`couchbase-migrations`** container run.
+
+### 2. Unified path (3.0+)
+
+Resolved **3.0+** and **`FORCE_LEGACY_MIGRATIONS` unset/false** -> **`unified-migrations`**
+(`maintenance:enable` -> `db:migrate` -> `maintenance:disable` -> `seed:prebuilt-content --if-present`).
+
+- You should see "Using Unified Migration Framework (resolved …)" and
+  `compose --profile database-migrations up unified-migrations`.
+
+- The API image must define **`npm run db:migrate`**. If it is missing, the container exits with an error.
+
+### 3. Break-glass: legacy on 3.x
+
+      FORCE_LEGACY_MIGRATIONS=true /vagrant/src/plextrac update -y
+
+Forces **`couchbase-migrations`** even when the resolved version is **3.x**.
+
+### 4. Run only the migration service (no full update)
+
+To test just the compose definition and the migration command (no install/update flow):
+
+- From the directory that has your compose file and `.env` (e.g. `/opt/plextrac` or
+  wherever `PLEXTRAC_HOME` points):
+
+      docker compose --profile database-migrations run --rm unified-migrations
+
+- This runs the `unified-migrations` service once. It will fail if the image does not have
+  `npm run db:migrate` (and the other scripts in the chain).
+
+- To run the legacy migration container for comparison:
+
+      docker compose --profile database-migrations up couchbase-migrations
+
+### 5. Trace which path runs (debug)
+
+      bash -x /vagrant/src/plextrac update -y 2>&1 | tee update.log
+
+- Search for `unified-migrations`, `couchbase-migrations`, `FORCE_LEGACY`, `_migration_resolve`.
+

--- a/src/_podman.sh
+++ b/src/_podman.sh
@@ -321,6 +321,22 @@ function podman_run_cb_migrations() {
   $volumes:z --replace --name="migrations" ${serviceValues[network]} -d $image 1>/dev/null
 }
 
+function podman_run_unified_migrations() {
+  var=$(declare -p "$1")
+  eval "declare -A serviceValues="${var#*=}
+  serviceValues[env-file]="--env-file ${PLEXTRAC_HOME:-}/.env"
+  serviceValues[migrations-env_vars]="-e COUCHBASE_URL=${COUCHBASE_URL:-http://plextracdb} -e CB_API_PASS=${CB_API_PASS} -e CB_API_USER=${CB_API_USER} -e REDIS_CONNECTION_STRING=${REDIS_CONNECTION_STRING:-redis} -e REDIS_PASSWORD=${REDIS_PASSWORD:?err} -e PG_HOST=${PG_HOST:-postgres} -e PG_MIGRATE_PATH=/usr/src/plextrac-api -e PG_SUPER_USER=${POSTGRES_USER:?err} -e PG_SUPER_PASSWORD=${POSTGRES_PASSWORD:?err} -e PG_CORE_ADMIN_PASSWORD=${PG_CORE_ADMIN_PASSWORD:?err} -e PG_CORE_ADMIN_USER=${PG_CORE_ADMIN_USER:?err} -e PG_CORE_DB=${PG_CORE_DB:?err} -e PG_RUNBOOKS_ADMIN_PASSWORD=${PG_RUNBOOKS_ADMIN_PASSWORD:?err} -e PG_RUNBOOKS_ADMIN_USER=${PG_RUNBOOKS_ADMIN_USER:?err} -e PG_RUNBOOKS_RW_PASSWORD=${PG_RUNBOOKS_RW_PASSWORD:?err} -e PG_RUNBOOKS_RW_USER=${PG_RUNBOOKS_RW_USER:?err} -e PG_RUNBOOKS_DB=${PG_RUNBOOKS_DB:?err} -e PG_CKEDITOR_ADMIN_PASSWORD=${PG_CKEDITOR_ADMIN_PASSWORD:?err} -e PG_CKEDITOR_ADMIN_USER=${PG_CKEDITOR_ADMIN_USER:?err} -e PG_CKEDITOR_DB=${PG_CKEDITOR_DB:?err} -e PG_CKEDITOR_RO_PASSWORD=${PG_CKEDITOR_RO_PASSWORD:?err} -e PG_CKEDITOR_RO_USER=${PG_CKEDITOR_RO_USER:?err} -e PG_CKEDITOR_RW_PASSWORD=${PG_CKEDITOR_RW_PASSWORD:?err} -e PG_CKEDITOR_RW_USER=${PG_CKEDITOR_RW_USER:?err} -e PG_TENANTS_WRITE_MODE=${PG_TENANTS_WRITE_MODE:-couchbase_only} -e PG_TENANTS_READ_MODE=${PG_TENANTS_READ_MODE:-couchbase_only} -e PG_CORE_RO_PASSWORD=${PG_CORE_RO_PASSWORD:?err} -e PG_CORE_RO_USER=${PG_CORE_RO_USER:?err} -e PG_CORE_RW_PASSWORD=${PG_CORE_RW_PASSWORD:?err} -e PG_CORE_RW_USER=${PG_CORE_RW_USER:?err} -e CKEDITOR_MIGRATE=${CKEDITOR_MIGRATE:-} -e CKEDITOR_SERVER_CONFIG=${CKEDITOR_SERVER_CONFIG:-} -e PG_CORE_AI_SQL_PASSWORD=${PG_CORE_AI_SQL_PASSWORD:?err} -e PG_CORE_AI_SQL_USER=${PG_CORE_AI_SQL_USER:?err} -e RUXPIN_ENABLED=${RUXPIN_ENABLED:-}"
+  PODMAN_API_IMAGE="${PODMAN_API_IMAGE:-docker.io/plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}}"
+  serviceValues[api-image]="${PODMAN_API_IMAGE}"
+  local env_vars="${serviceValues[migrations-env_vars]}"
+  local volumes="${serviceValues[migrations-volumes]}"
+  local image="${serviceValues[api-image]}"
+
+  debug "Running unified migrations (UMF / v3.0+)"
+  podman run ${serviceValues[env-file]} $env_vars --entrypoint='["/bin/sh","-c","npm run maintenance:enable && npm run db:migrate && npm run maintenance:disable && npm run seed:prebuilt-content --if-present"]' --restart=no $volumes:z --rm ${serviceValues[network]} $image
+  return $?
+}
+
 function podman_pull_images() {
 
   declare -A service_images

--- a/src/plextrac
+++ b/src/plextrac
@@ -138,6 +138,7 @@ function mod_help() {
   log "start                                ${DIM}manually start a PlexTrac instance if normal processes did not succeed${RESET}"
   log "stop                                 ${DIM}manually stops the PlexTrac instance. Not a part of normal maintenance${RESET}"
   log "update                               ${DIM}updates the management utility & applies any configuration or application updates${RESET}"
+  log "migration-plan                       ${DIM}show which migration path would run (unified vs legacy) without running migrations${RESET}"
   log ""
   info "Available flags to modify command behavior:"
   log " -h | --help                         ${DIM}prints this help message${RESET}"
@@ -148,6 +149,9 @@ function mod_help() {
   log " --install-dir | --plextrac-home     ${DIM}path to non-standard install directory. The default is /opt/plextrac${RESET}. Must be used during initialization."
   log " --install-timeout NUM               ${DIM}seconds to wait for install migrations to complete. The default is 600 (10 mins)${RESET}"
   log " --skip-system-updates               ${DIM}skip system updates during the initialization step${RESET}"
+  log ""
+  info "Migration (see also: ${GREEN}plextrac migration-plan${RESET}):"
+  log " FORCE_LEGACY_MIGRATIONS=true         ${DIM}use couchbase-migrations even on v3.0+ (break-glass)${RESET}"
 }
 
 
@@ -482,35 +486,128 @@ function mod_restart() {
   log "Done!"
 }
 
+# Sets globals USE_UMF, MIGRATION_RESOLVED_VERSION, MIGRATION_RESOLVED_SOURCE (pinned|image).
+# UMF (Unified Migration Framework) in the app enables DVU (Direct Version Upgrades) on v3+.
+# Rule: v3.0+ and FORCE_LEGACY_MIGRATIONS is not true -> unified-migrations (UMF path).
+# Otherwise -> couchbase-migrations (2.x images do not ship UMF).
+# When UPGRADE_STRATEGY is stable/edge/etc., version MUST come from image label; missing label -> die.
+function _migration_resolve_version_and_mode() {
+  FORCE_LEGACY_MIGRATIONS=${FORCE_LEGACY_MIGRATIONS:-false}
+  local version_being_pulled="${UPGRADE_STRATEGY:-stable}"
+  local resolved_from_image=false
+
+  # Pinned tag in .env matches image labels / tags: 2.26.5, 3.0, etc. (no "v" prefix).
+  if [[ "$version_being_pulled" != "stable" && "$version_being_pulled" =~ ^[0-9]+\.[0-9] ]]; then
+    MIGRATION_RESOLVED_SOURCE=pinned
+  else
+    MIGRATION_RESOLVED_SOURCE=image
+    resolved_from_image=true
+    if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+      local api_image="${PODMAN_API_IMAGE:-docker.io/plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}}"
+      version_being_pulled="$(container_client image inspect "$api_image" --format json 2>/dev/null | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version") // empty' 2>/dev/null || true)"
+      if [ -z "$version_being_pulled" ]; then
+        die "Could not read org.opencontainers.image.version from image ${api_image}. Pull the image or set UPGRADE_STRATEGY to an explicit version (e.g. 3.0). Refusing to start migrations without a known app version."
+      fi
+    else
+      local api_tag
+      api_tag="$(compose_client config --format json 2>/dev/null | jq -r '.services.plextracapi.image // empty')"
+      if [ -z "$api_tag" ]; then
+        die "Could not read services.plextracapi.image from compose config. Refusing to resolve migration path."
+      fi
+      version_being_pulled="$(container_client image inspect "$api_tag" --format json 2>/dev/null | jq -r '(.[].Config.Labels | ."org.opencontainers.image.version") // empty' 2>/dev/null || true)"
+      if [ -z "$version_being_pulled" ]; then
+        die "Could not read org.opencontainers.image.version from image ${api_tag}. Pull the plextracapi image for this tag or set UPGRADE_STRATEGY to an explicit version. Refusing to start migrations without a known app version."
+      fi
+    fi
+  fi
+
+  MIGRATION_RESOLVED_VERSION="$version_being_pulled"
+  local target_major
+  target_major="$(echo "$version_being_pulled" | cut -d. -f1)"
+
+  if [ "$resolved_from_image" = true ]; then
+    if [ -z "$version_being_pulled" ] || [ "$version_being_pulled" = "null" ] || ! [[ "$target_major" =~ ^[0-9]+$ ]]; then
+      die "Invalid app version from image label: '${version_being_pulled:-empty}'. Expected a semver like 2.28 or 3.0. Refusing to guess migration path."
+    fi
+  fi
+
+  USE_UMF=false
+  if [[ "$target_major" =~ ^[0-9]+$ ]] && [ "$target_major" -ge 3 ] && [ "$FORCE_LEGACY_MIGRATIONS" != "true" ]; then
+    USE_UMF=true
+  fi
+  if [ "$FORCE_LEGACY_MIGRATIONS" = "true" ] && [[ "$target_major" =~ ^[0-9]+$ ]] && [ "$target_major" -ge 3 ]; then
+    info "FORCE_LEGACY_MIGRATIONS=true: using couchbase-migrations (legacy) instead of unified-migrations for v${target_major}.x."
+  fi
+
+  [ "$USE_UMF" = "true" ] && debug "Using unified-migrations (UMF): resolved version ${MIGRATION_RESOLVED_VERSION} (source=${MIGRATION_RESOLVED_SOURCE})"
+}
+
+function mod_migration-plan() {
+  title "Migration path (dry-run)"
+  check_container_runtime
+  requires_user_plextrac
+  _migration_resolve_version_and_mode
+  info "UPGRADE_STRATEGY=${UPGRADE_STRATEGY:-unset}"
+  info "Resolved version (this step): ${MIGRATION_RESOLVED_VERSION}"
+  info "Resolved from: ${MIGRATION_RESOLVED_SOURCE} (pinned=UPGRADE_STRATEGY like 2.26.5; image=org.opencontainers.image.version)"
+  info "FORCE_LEGACY_MIGRATIONS=${FORCE_LEGACY_MIGRATIONS:-false}  -> if true, legacy even on v3.0+"
+  if [ "$USE_UMF" = "true" ]; then
+    info "Result: ${GREEN}unified-migrations${RESET} (UMF; DVU-capable on v3+)"
+  else
+    info "Result: ${GREEN}couchbase-migrations${RESET} (full legacy chain)"
+  fi
+}
+
 function run_cb_migrations() {
   info "Running Database Migrations"
   secs=${1:-300}
   endTime=$(( $(date +%s) + secs ))
-  # Run the cb migration container
+  _migration_resolve_version_and_mode
+
   if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-    podman_run_cb_migrations "svcValues"
-  else
-    compose_client --profile=database-migrations up -d couchbase-migrations --remove-orphans
+    if [ "$USE_UMF" == "true" ]; then
+      podman_run_unified_migrations "svcValues" || exit $?
+      info "Migrations completed"
+    else
+      podman_run_cb_migrations "svcValues"
+      info "Waiting up to 5 minutes for migrations to complete..."
+      while [ $(date +%s) -lt $endTime ]; do
+        local migration_exited=$(container_client inspect --format '{{.State.Status}}' `container_client ps -a | grep migrations 2>/dev/null | awk '{print $1}'`)
+        if [ "$migration_exited" == "exited" ]; then
+          printf "\r\033[K"
+          info "Migrations completed"
+          break
+        fi
+      done
+      if [ $(date +%s) -ge $endTime ]; then
+        error "Migration container timed out and may still be running. Please check the logs for more information"
+      fi
+    fi
+    return
   fi
+
+  # Docker/compose path (unified-migrations service runs maintenance, db:migrate, disable, seed in one container)
+  if [ "$USE_UMF" == "true" ]; then
+    info "Using Unified Migration Framework (resolved ${MIGRATION_RESOLVED_VERSION})"
+    compose_client --profile=database-migrations up unified-migrations
+    migrate_exit=$?
+    if [ $migrate_exit -ne 0 ]; then
+      error "Unified migrations failed (exit code $migrate_exit)"
+      exit $migrate_exit
+    fi
+    info "Migrations completed"
+    return
+  fi
+
+  compose_client --profile=database-migrations up -d couchbase-migrations --remove-orphans
   info "Waiting up to 5 minutes for migrations to complete..."
-  # While the duraction of 5 minutes is running, check if the migration container has exited
   while [ $(date +%s) -lt $endTime ]; do
-    local migration_exited=$(container_client inspect --format '{{.State.Status}}' `container_client ps -a | grep migrations 2>/dev/null | awk '{print $1}'`)
+    local migration_exited=$(container_client inspect --format '{{.State.Status}}' `container_client ps -a | grep couchbase-migrations 2>/dev/null | awk '{print $1}'`)
     if [ "$migration_exited" == "exited" ]; then
       printf "\r\033[K"
       info "Migrations completed"
       break
     fi
-    # This was mainly broken spinner code that was too noisy on cli
-    # for s in / - \\ \|; do
-    #     local log=""
-    #     local container=""
-    #     container="$(container_client ps -a | grep migrations 2>/dev/null | awk '{print $1}')"
-    #     log="$(container_client logs $container 2> /dev/null | tail -n 1 -q || true)"
-    #     printf "\r\033[K%s %s -- %s" "$s" "$container" "$log"
-    #     sleep .1
-    # done
-    # sleep 1
   done
   if [ $(date +%s) -ge $endTime ]; then
     error "Migration container timed out and may still be running. Please check the logs for more information"

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -88,6 +88,60 @@ services:
       PG_CORE_AI_SQL_USER: ${PG_CORE_AI_SQL_USER:?err}
       RUXPIN_ENABLED: ${RUXPIN_ENABLED:-}
 
+  unified-migrations:
+    profiles:
+    - "database-migrations"
+    depends_on:
+    - plextracdb
+    - redis
+    - postgres
+    image: "plextrac/plextracapi:${UPGRADE_STRATEGY:-stable}"
+    volumes:
+    - uploads:/usr/src/plextrac-api/uploads:rw
+    entrypoint: ""
+    command: |
+      sh -c
+        "npm run maintenance:enable &&
+         npm run db:migrate &&
+         npm run maintenance:disable &&
+         npm run seed:prebuilt-content --if-present"
+    environment:
+      COUCHBASE_URL: ${COUCHBASE_URL:-http://plextracdb}
+      CB_API_PASS: ${CB_API_PASS}
+      CB_API_USER: ${CB_API_USER}
+      REDIS_CONNECTION_STRING: ${REDIS_CONNECTION_STRING:-redis}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?err}
+      PG_HOST: ${PG_HOST:-postgres}
+      PG_MIGRATE_PATH: /usr/src/plextrac-api
+      PG_SUPER_USER: ${POSTGRES_USER:?err}
+      PG_SUPER_PASSWORD: ${POSTGRES_PASSWORD:?err}
+      PG_CORE_ADMIN_PASSWORD: ${PG_CORE_ADMIN_PASSWORD:?err}
+      PG_CORE_ADMIN_USER: ${PG_CORE_ADMIN_USER:?err}
+      PG_CORE_DB: ${PG_CORE_DB:?err}
+      PG_RUNBOOKS_ADMIN_PASSWORD: ${PG_RUNBOOKS_ADMIN_PASSWORD:?err}
+      PG_RUNBOOKS_ADMIN_USER: ${PG_RUNBOOKS_ADMIN_USER:?err}
+      PG_RUNBOOKS_RW_PASSWORD: ${PG_RUNBOOKS_RW_PASSWORD:?err}
+      PG_RUNBOOKS_RW_USER: ${PG_RUNBOOKS_RW_USER:?err}
+      PG_RUNBOOKS_DB: ${PG_RUNBOOKS_DB:?err}
+      PG_CKEDITOR_ADMIN_PASSWORD: ${PG_CKEDITOR_ADMIN_PASSWORD:?err}
+      PG_CKEDITOR_ADMIN_USER: ${PG_CKEDITOR_ADMIN_USER:?err}
+      PG_CKEDITOR_DB: ${PG_CKEDITOR_DB:?err}
+      PG_CKEDITOR_RO_PASSWORD: ${PG_CKEDITOR_RO_PASSWORD:?err}
+      PG_CKEDITOR_RO_USER: ${PG_CKEDITOR_RO_USER:?err}
+      PG_CKEDITOR_RW_PASSWORD: ${PG_CKEDITOR_RW_PASSWORD:?err}
+      PG_CKEDITOR_RW_USER: ${PG_CKEDITOR_RW_USER:?err}
+      PG_TENANTS_WRITE_MODE: ${PG_TENANTS_WRITE_MODE:-couchbase_only}
+      PG_TENANTS_READ_MODE: ${PG_TENANTS_READ_MODE:-couchbase_only}
+      CKEDITOR_MIGRATE: ${CKEDITOR_MIGRATE:-}
+      CKEDITOR_SERVER_CONFIG: ${CKEDITOR_SERVER_CONFIG:-}
+      PG_CORE_RO_PASSWORD: ${PG_CORE_RO_PASSWORD:?err}
+      PG_CORE_RO_USER: ${PG_CORE_RO_USER:?err}
+      PG_CORE_RW_PASSWORD: ${PG_CORE_RW_PASSWORD:?err}
+      PG_CORE_RW_USER: ${PG_CORE_RW_USER:?err}
+      PG_CORE_AI_SQL_PASSWORD: ${PG_CORE_AI_SQL_PASSWORD:?err}
+      PG_CORE_AI_SQL_USER: ${PG_CORE_AI_SQL_USER:?err}
+      RUXPIN_ENABLED: ${RUXPIN_ENABLED:-}
+
   plextracdb:
     environment:
       ADMIN_EMAIL: "${ADMIN_EMAIL:-}"


### PR DESCRIPTION
## Summary

Introduces a **Unified Migration Framework (UMF)** path for **app v3.0+** while keeping the existing **legacy** (`couchbase-migrations`) path for **2.x**. Routing uses the **resolved app version** (pinned `UPGRADE_STRATEGY` or `org.opencontainers.image.version` on the `plextracapi` image). **DVU** (direct version upgrades) is the operational outcome on v3+ once the image ships UMF; **no `DVU_ENABLED` flag**—behavior is version-driven, with an optional **break-glass** override.

## What changed

### `static/docker-compose.yml`
- New **`unified-migrations`** service (profile `database-migrations`):  
  `maintenance:enable` -> **`npm run db:migrate`** -> `maintenance:disable` -> `seed:prebuilt-content --if-present`  
- Same image/env pattern as legacy migrations where appropriate; does **not** duplicate the full pg/ETL legacy chain.

### `src/plextrac`
- **`_migration_resolve_version_and_mode`**: resolves version (pinned semver `X.Y[.Z]` or image label); **fails fast** if label missing when using non-pinned tags (e.g. `stable`).
- **Routing**: **major ≥ 3** and **`FORCE_LEGACY_MIGRATIONS` ≠ true** -> unified path; else legacy.
- **`run_cb_migrations`**: Docker uses `up unified-migrations` or `up -d couchbase-migrations` + wait; legacy wait targets **`couchbase-migrations`** explicitly.
- **`plextrac migration-plan`**: dry-run of resolved version and chosen path.
- Help text for **`FORCE_LEGACY_MIGRATIONS`** and **`migration-plan`**.

### `src/_podman.sh`
- **`podman_run_unified_migrations`**: single container run matching the unified compose command chain.

### `README.md` / `docs/development.md`
- Terminology: **UMF** vs **DVU**, version-based routing, break-glass flag, testing / `migration-plan`, plain semver (no `v` prefix) for pins/labels.

---

## How to test

- `plextrac migration-plan` from a real install (as `plextrac` user).
- On **2.x** image: expect **couchbase-migrations**.
- On **3.x** image: expect **unified-migrations** (requires `npm run db:migrate` in the API image).
- `FORCE_LEGACY_MIGRATIONS=true` on v3+: expect legacy path.

---

## Notes / follow-ups

- **v3 API image** must define **`npm run db:migrate`** (and seed/maintenance scripts) or unified migrations will fail at runtime.