### PR TITLE
Bugfix: Uploads backup archived into the directory being archived (podman)

### DIFF
--- a/src/_backup.sh
+++ b/src/_backup.sh
@@ -10,9 +10,9 @@ function mod_backup() {
   backup_ensureBackupDirectory
   backup_fullPostgresBackup
   backup_fullCouchbaseBackup || backupFailed=1
-  backup_fullUploadsBackup "svcValues"
+  backup_fullUploadsBackup "svcValues" || backupFailed=1
   if [ "$backupFailed" -ne 0 ]; then
-    error "Backup completed with errors - see Couchbase backup failure above"
+    error "Backup completed with errors - see the failure(s) above"
     exit 1
   fi
 }
@@ -50,20 +50,61 @@ function backup_fullUploadsBackup() {
 
   local current_date=$(date -u "+%Y-%m-%dT%H%M%Sz")
   local versionedFileName="${current_date}-uploads-v${PLEXTRAC_VERSION}.tar.gz"
+  local archivePath="${uploadsBackupDir}/${versionedFileName}"
+  local tarExit=0
 
- if [ "$CONTAINER_RUNTIME" == "podman" ]; then
-    podman exec --workdir="/usr/src/plextrac-api" plextracapi tar -czf "uploads/$versionedFileName" uploads
-    debug "Archiving uploads succeeded"
-    podman cp plextracapi:/usr/src/plextrac-api/uploads/$versionedFileName $uploadsBackupDir
-    debug "Copying to host succeeded"
-    podman exec --workdir="/usr/src/plextrac-api/uploads" plextracapi rm $versionedFileName
-    debug "Cleaned Archive from container"
+  # NEVER write the archive inside `uploads` - that is the tree being archived.
+  # An in-tree target makes tar read its own output (GNU tar on amd64 embeds it,
+  # doubling the archive) and tar always exits 1 because the directory mtime
+  # changes when the archive is created. Under `set -e` that exit 1 aborted this
+  # function before the copy-out and cleanup ran, so no backup reached the host
+  # and the archive was orphaned in the live volume for the next run to archive
+  # again, compounding on every run. Stream to stdout and let the host write it.
+  if [ "$CONTAINER_RUNTIME" == "podman" ]; then
+    # No -t on exec: a TTY would corrupt the binary stream.
+    podman exec --workdir="/usr/src/plextrac-api" plextracapi \
+      tar -czf - uploads > "$archivePath" || tarExit=$?
   else
-    debug "`compose_client run --user $(id -u) --no-deps -v ${uploadsBackupDir}:/backups \
-      --workdir /usr/src/plextrac-api --rm --entrypoint='' -T  $coreBackendComposeService \
-      tar -czf /backups/$versionedFileName uploads`"
+    # $uploadsBackupDir is bind-mounted at /backups, so this target is already
+    # outside the archived tree. Do not wrap this in `debug "`...`"` - command
+    # substitution inside an argument hides the exit code and silently swallows
+    # a failed backup.
+    compose_client run --user $(id -u) --no-deps -v ${uploadsBackupDir}:/backups \
+      --workdir /usr/src/plextrac-api --rm --entrypoint='' -T $coreBackendComposeService \
+      tar -czf /backups/$versionedFileName uploads || tarExit=$?
   fi
+
+  backup_verifyUploadsArchive "$tarExit" "$archivePath" || return 1
   log "Done."
+}
+
+# Validates the uploads tar. tar exits 1 when a file it is reading changes
+# underneath it, which is expected here: six services mount the uploads volume
+# read-write and the app keeps writing to it for the whole backup. The archive
+# is still complete and valid in that case, so only 2+ is a real failure.
+# Confirms the gzip stream too, so a truncated archive is never left behind
+# looking like a good backup.
+function backup_verifyUploadsArchive() {
+  local tarExit="$1"
+  local archivePath="$2"
+
+  if [ "$tarExit" -ge 2 ]; then
+    error "tar failed with status $tarExit while archiving uploads"
+    rm -f "$archivePath"
+    return 1
+  fi
+
+  if [ "$tarExit" -eq 1 ]; then
+    log "Some files changed while being read - expected on a running instance, archive is still valid"
+  fi
+
+  if ! gzip -t "$archivePath" 2>/dev/null; then
+    error "Uploads archive failed its integrity check and was discarded: $archivePath"
+    rm -f "$archivePath"
+    return 1
+  fi
+
+  debug "Uploads archive verified: `du -h "$archivePath" 2>/dev/null | cut -f1`"
 }
 
 function backup_fullCouchbaseBackup() {

--- a/src/plextrac
+++ b/src/plextrac
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-VERSION=0.8.0
+VERSION=0.8.1
 
 ## Podman Global Declaration Variable
 declare -A svcValues


### PR DESCRIPTION
## Problem

`backup_fullUploadsBackup` wrote its archive into the tree it was archiving:

```bash
podman exec --workdir="/usr/src/plextrac-api" plextracapi \
  tar -czf "uploads/$versionedFileName" uploads
```

GNU tar always exits 1 here, because creating the archive inside `uploads`
changes that directory's mtime mid-read. `src/plextrac` runs `set -Eeuo pipefail`
and dispatches `$mod` as a plain simple command, so errexit is live and that
exit 1 aborted the function before reaching either:

- `podman cp`, so **no uploads backup ever reached the host**
- `rm`, so the archive was **orphaned inside the live uploads volume**

Every later run then archived the previous orphans. Nothing reclaims them:
`clean_sweepUploadsCache` only sweeps `json|xml|ptrac|csv|nessus`.

## Evidence

Five runs against `plextrac/plextracapi:3.3` with the cleanup skipped, which is
what errexit causes:

| Run | tar exit | Archive | uploads dir |
|-----|----------|---------|-------------|
| 1 | 1 | 32 MB | 61 MB |
| 3 | 1 | 336 MB | 505 MB |
| 5 | 1 | 1203 MB | 2369 MB |

29 MB of real uploads to 2.37 GB, with five orphans left behind.

Field data from an affected instance matches the model to within 0.08%. With
C as the compressed size of the real uploads, each archive equals C plus the
orphans already present, since orphans are already compressed and pass through
gzip at 1:1.

## Fix

- Podman path streams to stdout and the host writes the file, dropping the
  in-tree target, the `podman cp` and the `rm`. No `-t` on exec, since a TTY
  would corrupt the binary stream.
- New `backup_verifyUploadsArchive`: tar exit 1 is tolerated with a note
  (expected, six services mount the uploads volume read-write and the app
  writes throughout a backup), 2+ is fatal, and the result gets a `gzip -t` so
  a truncated archive is never left looking healthy. Failed archives are
  removed instead of kept.
- Docker path now checks its exit code too. It was wrapped in a `debug` command
  substitution, and command substitution inside an argument discards the status,
  so failures there were silently swallowed.
- `backup_fullUploadsBackup` feeds `backupFailed` like the couchbase call does,
  so a failure is reported in the summary instead of killing the run mid-way.
- Version bumped to 0.8.1.

## Testing

`bash -n` clean across all modules. Shellcheck findings on `_backup.sh` went
from 71 to 58.

All paths exercised against the real functions with `podman` stubbed:

| Case | Return | Archive |
|------|--------|---------|
| tar exit 0 | 0 | kept |
| tar exit 1, app writing | 0 + note | kept |
| tar exit 2 | 1 + error | deleted |
| corrupt / truncated stream | 1 + error | deleted |

Confirmed the ERR trap no longer fires on a tar exit 1, so execution now
continues past the uploads step instead of aborting.